### PR TITLE
fix - example 3 twitter generated reactUtils when it shouldn't

### DIFF
--- a/examples/3-twitter-clone/src/app/models/MessageModel.base.ts
+++ b/examples/3-twitter-clone/src/app/models/MessageModel.base.ts
@@ -44,5 +44,5 @@ export function selectFromMessage() {
   return new MessageModelSelector()
 }
 
-export const messageModelPrimitives = selectFromMessage().id.timestamp.text.toString()
+export const messageModelPrimitives = selectFromMessage().timestamp.text.toString()
 

--- a/examples/3-twitter-clone/src/app/models/UserModel.base.ts
+++ b/examples/3-twitter-clone/src/app/models/UserModel.base.ts
@@ -37,5 +37,5 @@ export function selectFromUser() {
   return new UserModelSelector()
 }
 
-export const userModelPrimitives = selectFromUser().id.name.avatar.toString()
+export const userModelPrimitives = selectFromUser().name.avatar.toString()
 

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -41,7 +41,7 @@ function generate(
 
   generateTypes()
   generateRootStore()
-  if (!modelsOnly || !noReact) {
+  if (!modelsOnly && !noReact) {
     generateReactUtils()
   }
   generateBarrelFile(files)


### PR DESCRIPTION
Twitter example 3 was no longer working. When scaffolding the server models, the reactUtils were generated while it shouldn't. It shouldn't be generated because '--modelsOnly' was passed to the scaffolder. 

The presence of the reactUtils causes a typescript compiler error, which blocks the server start in the Twitter example. The reactUtils couldn't be compiled by typescript because createStoreContext requires a store that is based on MSTGQLStore, which it ain't.

The fix can be found  in generate.js. The other changes are coming from the latest scaffolding output changes.

Thanks,
  Derk