### PR TITLE
allow multiple queries

### DIFF
--- a/examples/1-getting-started/src/app/models/RootStore.base.ts
+++ b/examples/1-getting-started/src/app/models/RootStore.base.ts
@@ -22,7 +22,7 @@ export const RootStoreBase = MSTGQLStore
     todos: types.optional(types.map(types.late(() => TodoModel)), {})
   })
   .actions(self => ({
-    queryTodos(variables?: {  }, resultSelector: string | ((qb: TodoModelSelector) => TodoModelSelector) = todoModelPrimitives.toString(), options: QueryOptions = {}) {
+    queryTodos(variables?: {}, resultSelector: string | ((qb: TodoModelSelector) => TodoModelSelector) = todoModelPrimitives.toString(), options: QueryOptions = {}) {
       return self.query<typeof TodoModel.Type[]>(`query todos { todos {
         ${typeof resultSelector === "function" ? resultSelector(new TodoModelSelector()).toString() : resultSelector}
       } }`, variables, options)
@@ -32,9 +32,9 @@ export const RootStoreBase = MSTGQLStore
         ${typeof resultSelector === "function" ? resultSelector(new TodoModelSelector()).toString() : resultSelector}
       } }`, variables, optimisticUpdate)
     },
-    mutateCreateTodo(variables: { todo: CreateTodoInput }, resultSelector: string | ((qb: TodoModelSelector) => TodoModelSelector) = todoModelPrimitives, optimisticUpdate?: () => void) {
+    mutateCreateTodo(variables: { todo: CreateTodoInput }, resultSelector: string | ((qb: TodoModelSelector) => TodoModelSelector) = todoModelPrimitives.toString(), optimisticUpdate?: () => void) {
       return self.mutate<typeof TodoModel.Type>(`mutation createTodo($todo: CreateTodoInput!) { createTodo(todo: $todo) {
         ${typeof resultSelector === "function" ? resultSelector(new TodoModelSelector()).toString() : resultSelector}
       } }`, variables, optimisticUpdate)
-    },    
+    },
   }))

--- a/examples/4-apollo-tutorial/client/src/containers/cart-item.js
+++ b/examples/4-apollo-tutorial/client/src/containers/cart-item.js
@@ -21,6 +21,6 @@ export default observer(function CartItem({ launchId }) {
   return query.case({
     error: error => <p>ERROR: {error.message}</p>,
     loading: () => <p>Loading...</p>,
-    data: launch => <LaunchTile launch={launch} />
+    data: ({ launch }) => <LaunchTile launch={launch} />
   })
 })

--- a/examples/4-apollo-tutorial/client/src/models/RootStore.base.js
+++ b/examples/4-apollo-tutorial/client/src/models/RootStore.base.js
@@ -3,16 +3,16 @@
 import { types } from "mobx-state-tree"
 import { MSTGQLStore, configureStoreMixin } from "mst-gql"
 
- import { LaunchConnectionModel } from "./LaunchConnectionModel"
- import { launchConnectionModelPrimitives, LaunchConnectionModelSelector } from "./LaunchConnectionModel.base"
- import { LaunchModel } from "./LaunchModel"
- import { launchModelPrimitives, LaunchModelSelector } from "./LaunchModel.base"
- import { MissionModel } from "./MissionModel"
- import { missionModelPrimitives, MissionModelSelector } from "./MissionModel.base"
- import { RocketModel } from "./RocketModel"
- import { rocketModelPrimitives, RocketModelSelector } from "./RocketModel.base"
- import { UserModel } from "./UserModel"
- import { userModelPrimitives, UserModelSelector } from "./UserModel.base"
+import { LaunchConnectionModel } from "./LaunchConnectionModel"
+import { launchConnectionModelPrimitives, LaunchConnectionModelSelector } from "./LaunchConnectionModel.base"
+import { LaunchModel } from "./LaunchModel"
+import { launchModelPrimitives, LaunchModelSelector } from "./LaunchModel.base"
+import { MissionModel } from "./MissionModel"
+import { missionModelPrimitives, MissionModelSelector } from "./MissionModel.base"
+import { RocketModel } from "./RocketModel"
+import { rocketModelPrimitives, RocketModelSelector } from "./RocketModel.base"
+import { UserModel } from "./UserModel"
+import { userModelPrimitives, UserModelSelector } from "./UserModel.base"
 
 /**
 * Store, managing, among others, all the objects received through graphQL

--- a/examples/4-apollo-tutorial/client/src/pages/launch.js
+++ b/examples/4-apollo-tutorial/client/src/pages/launch.js
@@ -25,7 +25,7 @@ export default observer(function Launch({ launchId }) {
   return query.case({
     error: error => <p>ERROR: {error.message}</p>,
     loading: () => <Loading />,
-    data: launch => (
+    data: ({ launch }) => (
       <Fragment>
         <Header image={launch.mission.missionPatch}>
           {launch.mission.name}

--- a/examples/4-apollo-tutorial/client/src/pages/launches.js
+++ b/examples/4-apollo-tutorial/client/src/pages/launches.js
@@ -12,7 +12,7 @@ export default observer(function Launches() {
       {query.case({
         error: () => <p>ERROR</p>,
         loading: () => <Loading />,
-        data: launchConnection => (
+        data: ({ launches: launchConnection }) => (
           <Fragment>
             {launchConnection.launches.map(launch => (
               <LaunchTile key={launch.id} launch={launch} />

--- a/examples/4-apollo-tutorial/server/package.json
+++ b/examples/4-apollo-tutorial/server/package.json
@@ -20,7 +20,7 @@
     "isemail": "^3.1.3",
     "nodemon": "^1.18.4",
     "sequelize": "^5.3.0",
-    "sqlite3": "^4.0.3"
+    "sqlite3": "^4.0.9"
   },
   "devDependencies": {
     "apollo": "^2.1.8",

--- a/examples/4-apollo-tutorial/server/yarn.lock
+++ b/examples/4-apollo-tutorial/server/yarn.lock
@@ -4542,11 +4542,6 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.2.tgz#f51dc7ae66ba7d5d55e1e6d4d8092e802c9aefe7"
   integrity sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==
 
-nan@~2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
-  integrity sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==
-
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -5957,12 +5952,12 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sqlite3@^4.0.3:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-4.0.6.tgz#e587b583b5acc6cb38d4437dedb2572359c080ad"
-  integrity sha512-EqBXxHdKiwvNMRCgml86VTL5TK1i0IKiumnfxykX0gh6H6jaKijAXvE9O1N7+omfNSawR2fOmIyJZcfe8HYWpw==
+sqlite3@^4.0.9:
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-4.0.9.tgz#cff74550fa5a1159956815400bdef69245557640"
+  integrity sha512-IkvzjmsWQl9BuBiM4xKpl5X8WCR4w0AeJHRdobCdXZ8dT/lNc1XS6WqvY35N6+YzIIgzSBeY5prdFObID9F9tA==
   dependencies:
-    nan "~2.10.0"
+    nan "^2.12.1"
     node-pre-gyp "^0.11.0"
     request "^2.87.0"
 

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -3,7 +3,6 @@ import stringify from "fast-json-stable-stringify"
 import { DocumentNode, print } from "graphql"
 
 import { StoreType } from "./MSTGQLStore"
-import { getFirstValue } from "./utils"
 import { observable, action } from "mobx"
 
 export type CaseHandlers<T, R> = {
@@ -101,7 +100,6 @@ export class Query<T = unknown> implements PromiseLike<T> {
       this.store.__cacheResponse(this.cacheKey, data)
     }
 
-    const value = getFirstValue(data)
     if (this.options.raw) {
       this.loading = false
       this.data = data
@@ -109,7 +107,10 @@ export class Query<T = unknown> implements PromiseLike<T> {
     } else {
       try {
         this.loading = false
-        const normalized = this.store.merge(value)
+        const normalized: any = {}
+        Object.keys(data).forEach(key => {
+          normalized[key] = this.store.merge(data[key])
+        })
         this.data = normalized
         this.onResolve(this.data!)
       } catch (e) {

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -107,7 +107,7 @@ export class Query<T = unknown> implements PromiseLike<T> {
     } else {
       try {
         this.loading = false
-        const normalized: any = {}
+        const normalized: { [key: string]: any } = {}
         Object.keys(data).forEach(key => {
           normalized[key] = this.store.merge(data[key])
         })


### PR DESCRIPTION
This would allow for multiple queries like so:

```js
export const GET_TODOS = gql`
  query UserWithTodos {
    user {
      id
      username
      fullname
    }
    todos {
      id
      name
    }
  }
`;
```

This is also breaking change because when using `useQuery` with react you to use the key of the query instead of `data` directly

Also unsure about the types