### PR TITLE
remove outdated instructions about running examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,20 +670,6 @@ const RootStore = RootStoreBase.extend(
 
 # 🙈 Examples 🙈
 
-### Running the examples
-
-Run the following in the example directory
-
-```
-yarn global add realpath # not needed for Linux users
-yarn
-yarn start
-```
-
-All examples start on url http://localhost:3000/
-
-Overview of the examples:
-
 ### 1. Getting started
 
 The [`1-getting-started](examples/1-getting-started) example is a very trivial project, that shows how to use `mst-gql` together with TypeScript and React. Features:


### PR DESCRIPTION
As far as I can tell it isn't possible to run the examples this way. I still haven't been able to get example 1 running myself (and haven't had a chance to check the others). But it will probably reduce at least some confusion in the short term to remove outdated instructions.