### PR TITLE
Add allowFieldArgs

### DIFF
--- a/generator/config.js
+++ b/generator/config.js
@@ -1,8 +1,8 @@
-const { existsSync } = require("fs");
-const { resolve } = require("path");
-const cosmiconfig = require('cosmiconfig');
+const { existsSync } = require("fs")
+const { resolve } = require("path")
+const cosmiconfig = require("cosmiconfig")
 
-const explorer = cosmiconfig('mst-gql');
+const explorer = cosmiconfig("mst-gql")
 
 const defaultConfig = {
   excludes: [],
@@ -13,15 +13,16 @@ const defaultConfig = {
   outDir: "src/models",
   roots: [],
   noReact: false,
+  allowFieldArgs: false
 }
 
 exports.getConfig = function getConfig() {
   try {
-    const result = explorer.searchSync();
-    return result ? result.config : defaultConfig;
+    const result = explorer.searchSync()
+    return result ? result.config : defaultConfig
   } catch (e) {
-    console.error(e.message);
-    return defaultConfig;
+    console.error(e.message)
+    return defaultConfig
   }
 }
 
@@ -35,9 +36,10 @@ exports.mergeConfigs = function mergeConfigs(args, config) {
   const excludes = args["--excludes"]
     ? args["--excludes"].split(",").map(s => s.trim())
     : config.excludes
-  const modelsOnly =!!args["--modelsOnly"] || config.modelsOnly
+  const modelsOnly = !!args["--modelsOnly"] || config.modelsOnly
   const forceAll = !!args["--force"] || config.force
   const noReact = !!args["--noReact"] || config.noReact
+  const allowFieldArgs = !!args["--allowFieldArgs"] || config.allowFieldArgs
 
   return {
     format,
@@ -46,6 +48,7 @@ exports.mergeConfigs = function mergeConfigs(args, config) {
     roots,
     excludes,
     modelsOnly,
-    forceAll
+    forceAll,
+    allowFieldArgs
   }
 }

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -23,7 +23,8 @@ function generate(
   excludes = [],
   generationDate = "a long long time ago...",
   modelsOnly = false,
-  noReact = false
+  noReact = false,
+  allowFieldArgs = false
 ) {
   excludes.push(...buildInExcludes)
 
@@ -294,7 +295,7 @@ ${generateFragments(name, primitiveFields, nonPrimitiveFields)}
     let modelProperties = ""
     if (type.fields) {
       modelProperties = type.fields
-        .filter(field => field.args.length === 0)
+        .filter(field => (allowFieldArgs ? true : field.args.length === 0))
         .map(field => handleField(field))
         .join("\n")
     }

--- a/generator/mst-gql-scaffold.js
+++ b/generator/mst-gql-scaffold.js
@@ -5,7 +5,7 @@ const fs = require("fs")
 const child_process = require("child_process")
 const graphql = require("graphql")
 
-const { getConfig, mergeConfigs } = require('./config');
+const { getConfig, mergeConfigs } = require("./config")
 const { generate, writeFiles } = require("./generate")
 
 const definition = {
@@ -16,7 +16,8 @@ const definition = {
   "--modelsOnly": Boolean,
   "--force": Boolean,
   "--noReact": Boolean,
-  "--separate": Boolean
+  "--separate": Boolean,
+  "--allowFieldArgs": Boolean
 }
 
 function main() {
@@ -33,7 +34,17 @@ function main() {
     throw e
   }
 
-  const { format, outDir, input, roots, excludes, modelsOnly, forceAll, noReact } = mergeConfigs(args, config);
+  const {
+    format,
+    outDir,
+    input,
+    roots,
+    excludes,
+    modelsOnly,
+    forceAll,
+    noReact,
+    allowFieldArgs
+  } = mergeConfigs(args, config)
   const separate = !!args["--separate"]
 
   console.log(
@@ -93,7 +104,8 @@ function main() {
     excludes,
     new Date().toUTCString(),
     modelsOnly,
-    noReact
+    noReact,
+    allowFieldArgs
   )
   writeFiles(outDir, files, format, forceAll, true, separate)
 }


### PR DESCRIPTION
Fields with arguments are ignored by default by the generator. With
--allowFieldArgs one can have approriate definitions generated for
such fields as well.

Fixes #46 