### PR TITLE
Fix SSR issues #94 & #95 & (somewhat incidentally) bug #91

### DIFF
--- a/examples/5-nextjs/components/todos.tsx
+++ b/examples/5-nextjs/components/todos.tsx
@@ -1,6 +1,6 @@
 import { observer } from "mobx-react"
 import { selectFromTodo, useQuery } from "../src/models"
-import { UserView } from "./users"
+import { UserPreview } from "./users"
 
 const todoSelector = selectFromTodo()
   .text
@@ -21,7 +21,7 @@ const TodosList = observer(({ todos }) => {
             toggle
           </button>
           &emsp;
-          Assignee: <UserView userId={todo.assignee.id}/>
+          Assignee: <UserPreview userId={todo.assignee.id}/>
         </li>
       ))}
     </ul>

--- a/examples/5-nextjs/components/users.tsx
+++ b/examples/5-nextjs/components/users.tsx
@@ -1,17 +1,35 @@
 import { observer } from "mobx-react"
 import { useQuery } from "../src/models"
 
-// this component declares it's own data dependencies
-export const UserView = observer(({ userId }) => {
-  const { error, loading, data } = useQuery(store => {
-    return store.queryUser({ id: userId }, user => user.name.likes)
+// this component declares it's own data dependencies, and is only rendered client-side (uses noSsr)
+export const UsersView = observer(({}) => {
+  const { error, data, loading, query } = useQuery(store => {
+    return store.queryUsers({}, user => user.name.likes, {noSsr: true})
   })
   if (error) return error.message
   if (!data) return "Loading..."
   return (
     <>
-      <strong>{data.user.name}</strong>
-      <em> (likes: {data.user.likes.join(" + ")})</em>
+      <ul>
+        {data.users.map(user => (
+          <li key={user.id}>
+            <strong>{user.name}</strong>
+            <em> (likes: {user.likes.join(" + ")})</em>
+          </li>
+        ))}
+      </ul>
+      {loading ? "Loading..." : <button onClick={query!.refetch}>Refetch</button>}
     </>
   )
+})
+
+// this component also declares it's own data dependencies, but is rendered server-side
+// it's only rendered after the query in parent AllTodosView or DoneTodosView is done loading
+export const UserPreview = observer(({ userId }) => {
+  const { error, data } = useQuery(store => {
+    return store.queryUser({ id: userId }, user => user.name)
+  })
+  if (error) return error.message
+  if (!data) return "Loading..."
+  return (<strong>{data.user.name}</strong>)
 })

--- a/examples/5-nextjs/pages/index.tsx
+++ b/examples/5-nextjs/pages/index.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react"
 import { AllTodosView, DoneTodosView } from "../components/todos"
+import {UsersView} from "../components/users"
 
 export default function Index() {
-  const [showDoneTodos, setShowDoneTodos] = useState(false)
+  const [showDoneTodos, setShowDoneTodos] = useState(true)
   return (
     <>
       <h3>All Todos</h3>
@@ -13,6 +14,9 @@ export default function Index() {
         {showDoneTodos ? "Hide" : "Show"}
       </button>
       {showDoneTodos && <DoneTodosView/>}
+      <hr/>
+      <h3>Users (query with no SSR)</h3>
+      <UsersView/>
     </>
   )
 }

--- a/examples/5-nextjs/server/schema.js
+++ b/examples/5-nextjs/server/schema.js
@@ -5,6 +5,7 @@ const typeDefs = `
     todos: [Todo],
     doneTodos: [Todo],
     user(id: ID!): User,
+    users: [User],
   }
   type Mutation {
     toggleTodo(id: ID!): Todo,
@@ -33,6 +34,9 @@ const resolvers = {
     user: (root, args) => {
       return store.users.find(user => user.id === args.id)
     },
+    users: () => {
+      return store.users
+    }
   },
   Mutation: {
     toggleTodo: (root, args) => {

--- a/examples/5-nextjs/server/store.js
+++ b/examples/5-nextjs/server/store.js
@@ -33,4 +33,11 @@ const store = {
   ]
 }
 
+// Force frequently changing data in user
+/* setInterval(() => {
+  store.users.forEach(user => {
+    user.name = user.name.split(' ').reverse().join(' ')
+  })
+}, 500) */
+
 module.exports = { store }

--- a/examples/5-nextjs/src/models/RootStore.base.ts
+++ b/examples/5-nextjs/src/models/RootStore.base.ts
@@ -36,6 +36,11 @@ export const RootStoreBase = MSTGQLStore
         ${typeof resultSelector === "function" ? resultSelector(new UserModelSelector()).toString() : resultSelector}
       } }`, variables, options)
     },
+    queryUsers(variables?: {  }, resultSelector: string | ((qb: UserModelSelector) => UserModelSelector) = userModelPrimitives.toString(), options: QueryOptions = {}) {
+      return self.query<{ users: UserModelType[]}>(`query users { users {
+        ${typeof resultSelector === "function" ? resultSelector(new UserModelSelector()).toString() : resultSelector}
+      } }`, variables, options)
+    },
     mutateToggleTodo(variables: { id: string }, resultSelector: string | ((qb: TodoModelSelector) => TodoModelSelector) = todoModelPrimitives.toString(), optimisticUpdate?: () => void) {
       return self.mutate<{ toggleTodo: TodoModelType}>(`mutation toggleTodo($id: ID!) { toggleTodo(id: $id) {
         ${typeof resultSelector === "function" ? resultSelector(new TodoModelSelector()).toString() : resultSelector}

--- a/src/MSTGQLStore.ts
+++ b/src/MSTGQLStore.ts
@@ -17,18 +17,25 @@ export const MSTGQLStore = types
   .model("MSTGQLStore", {
     __queryCache: types.optional(types.map(types.frozen()), {})
   })
-  .volatile((self): { ssr: boolean; __promises: Set<Promise<unknown>> } => {
+  .volatile((self): {
+    ssr: boolean
+    __promises: Set<Promise<unknown>>
+    __afterInit: boolean
+  } => {
     const {
       ssr = false
     }: {
       ssr: boolean
     } = getEnv(self)
     return {
+      ssr,
       __promises: new Set(),
-      ssr
+      __afterInit: false
     }
   })
   .actions(self => {
+    Promise.resolve().then(() => (self as any).__onAfterInit())
+
     const {
       gqlHttpClient, // TODO: rename to requestHandler
       gqlWsClient // TODO: rename to streamHandler
@@ -147,6 +154,9 @@ export const MSTGQLStore = types
       },
       __cacheResponse(key: string, response: any) {
         self.__queryCache.set(key, response)
+      },
+      __onAfterInit() {
+        self.__afterInit = true
       }
     }
   })

--- a/src/MSTGQLStore.ts
+++ b/src/MSTGQLStore.ts
@@ -5,6 +5,7 @@ import { DocumentNode } from "graphql"
 import { mergeHelper } from "./mergeHelper"
 import { getFirstValue } from "./utils"
 import { QueryOptions, Query } from "./Query"
+import { deflateHelper } from "./deflateHelper"
 
 export interface RequestHandler<T = any> {
   request(query: string, variables: any): Promise<T>
@@ -42,6 +43,10 @@ export const MSTGQLStore = types
 
     function merge(data: unknown) {
       return mergeHelper(self, data)
+    }
+
+    function deflate(data: unknown) {
+      return deflateHelper(self, data)
     }
 
     function rawRequest(query: string, variables: any): Promise<any> {
@@ -130,6 +135,7 @@ export const MSTGQLStore = types
     // exposed actions
     return {
       merge,
+      deflate,
       mutate,
       query,
       subscribe,

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -45,7 +45,11 @@ export class Query<T = unknown> implements PromiseLike<T> {
     this.query = typeof query === "string" ? query : print(query)
     // possible optimization: merge double in-flight requests
     let fetchPolicy = options.fetchPolicy || "cache-and-network"
-    if (this.store.ssr && !this.options.noSsr && (isServer || !store.__afterInit)) {
+    if (
+      this.store.ssr &&
+      !this.options.noSsr &&
+      (isServer || !store.__afterInit)
+    ) {
       fetchPolicy = "cache-first"
     }
     this.fetchPolicy = fetchPolicy

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -88,16 +88,16 @@ export class Query<T = unknown> implements PromiseLike<T> {
     }
   }
 
-  refetch = action(
-    (): Promise<T> => {
-      return Promise.resolve().then(() => {
+  refetch = (): Promise<T> => {
+    return Promise.resolve().then(
+      action(() => {
         if (!this.loading) {
           this.fetchResults()
         }
         return this.promise
       })
-    }
-  )
+    )
+  }
 
   private fetchResults() {
     this.loading = true

--- a/src/deflateHelper.ts
+++ b/src/deflateHelper.ts
@@ -5,12 +5,11 @@ export function deflateHelper(store: any, data: any) {
 
     const { __typename, id } = data
 
-    // GQL object
-    if (__typename && store.isKnownType(__typename)) {
-      // GQL object with known type, keep only __typename & id
+    if (__typename && store.isRootType(__typename)) {
+      // GQL object with root type, keep only __typename & id
       return { __typename, id }
     } else {
-      // GQL object with unknown type, return object with all props deflated
+      // GQL object with non-root type, return object with all props deflated
       const snapshot: any = {}
       for (const key in data) {
         snapshot[key] = deflate(data[key])

--- a/src/deflateHelper.ts
+++ b/src/deflateHelper.ts
@@ -1,0 +1,23 @@
+export function deflateHelper(store: any, data: any) {
+  function deflate(data: any): any {
+    if (!data || typeof data !== "object") return data
+    if (Array.isArray(data)) return data.map(deflate)
+
+    const { __typename, id } = data
+
+    // GQL object
+    if (__typename && store.isKnownType(__typename)) {
+      // GQL object with known type, keep only __typename & id
+      return { __typename, id }
+    } else {
+      // GQL object with unknown type, return object with all props deflated
+      const snapshot: any = {}
+      for (const key in data) {
+        snapshot[key] = deflate(data[key])
+      }
+      return snapshot
+    }
+  }
+
+  return deflate(data)
+}

--- a/src/react.tsx
+++ b/src/react.tsx
@@ -25,9 +25,13 @@ export async function getDataFromTree<STORE extends typeof MSTGQLStore.Type>(
     tree: React.ReactElement<any>
   ) => string = require("react-dom/server").renderToStaticMarkup
 ): Promise<string> {
-  const html = renderFunction(tree)
-  await Promise.all(client.__promises)
-  return html
+  while (true) {
+    const html = renderFunction(tree)
+    if (client.__promises.size === 0) {
+      return html
+    }
+    await Promise.all(client.__promises)
+  }
 }
 
 function normalizeQuery<STORE extends typeof MSTGQLStore.Type, DATA>(


### PR DESCRIPTION
I started working on fixing #94 with my proposed solution (force fetchPolicy to 'cache-first' when on server or first render on client, and render+wait repeatedly in getDataFromTree) but found that getDataFromTree was still entering an infinite loop, since `store.query()` still pushes a promise (to store.__promises) when it's a cache hit (i.e. just getting the results from the cache, synchronously).

So it was necessary to rework the control-flow of the `Query` class, so that we only `store.pushPromise()` when there is some actual async work to do, and otherwise just set the results (`data` or `error`) and the `promise` (which is already settled). The current code in master follows a shared path of execution once it has data, regardless of whether it is from the cache or from a fresh response (and with no use of a param/flag to indicate which). That is also the cause #91. I separated out two execution paths `fetchResults` & `useCachedResults`, and simplified the async control-flow (I have never found it helpful to pass around a promise's `resolve` & `reject` handlers. There is a reason they are only meant to be called inside the promises callback, as in `new Promise(callback)`). Instead of repeating the problematic code in the new `useCachedResults` path, there I put the `data` through a new `store.deflate` method (removes data properties from objects of known types) before putting it through `store.merge` (only if query is not "raw"). This is all done in 00a8366.

I didn't make the 2nd step (see #91) of removing the (above mentioned) data properties of known types from the `__queryCache` (which would be awesome) because the `query` method can be called with the `raw` option, and that will need the full, inflated (un-`deflate`d) data to be in the cache. To deal with that I propose a new option for the `RootStore` constructor: `cacheMode: "raw" | "normalized"` to indicate how you want your data cached. With 'raw' things behave exactly as they do already. With 'normalized', the data is put through `store.deflate()` before saving to __queryCache. The data no longer needs to be `deflate`d just before `merge`ing. If query is called with `raw: true`, the data should be put through a new `store.inflate()` method before being returned, which will add the data props back to objects of known types. This way we can save many bytes in __queryCache (for SSR or serializing/deserializing for localStorage) while keeping first-class support for "raw" queries. 

@chrisdrackett @mattiasewers What do you think of my proposed `cacheMode: "raw" | "normalized"` option? We could default it to "raw" for now, since that is the current behavior, and in the version 1 release switch it to "normalized" since that is (I imagine) what people would want in most cases for performance.

The other commits in this PR are pretty straight-forward I think. 
- 2a8950f Fix SSR, closes #94, closes #95 
- c726b82 Add `noSsr: boolean` query option to skip fetching query on server side
- bf4e35a [5-nextjs] Demo (1) layered SSR queries. (2) noSsr query option
