### PR TITLE
[optimization] Deduplicate identical concurrent query requests

### DIFF
--- a/src/Query.ts
+++ b/src/Query.ts
@@ -34,7 +34,7 @@ export class Query<T = unknown> implements PromiseLike<T> {
   public query: string
   public promise!: Promise<T>
   private fetchPolicy: FetchPolicy
-  private cacheKey: string
+  private queryKey: string
 
   constructor(
     public store: StoreType,
@@ -43,7 +43,8 @@ export class Query<T = unknown> implements PromiseLike<T> {
     public options: QueryOptions = {}
   ) {
     this.query = typeof query === "string" ? query : print(query)
-    // possible optimization: merge double in-flight requests
+    this.queryKey = this.query + stringify(variables)
+
     let fetchPolicy = options.fetchPolicy || "cache-and-network"
     if (
       this.store.ssr &&
@@ -53,12 +54,13 @@ export class Query<T = unknown> implements PromiseLike<T> {
       fetchPolicy = "cache-first"
     }
     this.fetchPolicy = fetchPolicy
-    this.cacheKey = this.query + stringify(variables)
+
     if (this.store.ssr && this.options.noSsr && isServer) {
       this.promise = Promise.resolve() as any
       return
     }
-    const inCache = this.store.__queryCache.has(this.cacheKey)
+
+    const inCache = this.store.__queryCache.has(this.queryKey)
     switch (this.fetchPolicy) {
       case "no-cache":
       case "network-only":
@@ -105,22 +107,23 @@ export class Query<T = unknown> implements PromiseLike<T> {
 
   private fetchResults() {
     this.loading = true
-    this.promise = this.store
-      .rawRequest(this.query, this.variables)
-      .then((data: any) => {
-        // cache query and response
-        if (this.fetchPolicy !== "no-cache") {
-          this.store.__cacheResponse(this.cacheKey, data)
-        }
-        return this.options.raw ? data : this.store.merge(data)
-      })
-    if (this.store.ssr) {
-      this.promise = this.promise.finally(() => {
-        this.store.unpushPromise(this.promise)
-      })
-      this.store.pushPromise(this.promise)
+    let promise: Promise<T>
+    const existingPromise = this.store.__promises.get(this.queryKey)
+    if (existingPromise) {
+      promise = existingPromise as Promise<T>
+    } else {
+      promise = this.store.rawRequest(this.query, this.variables)
+      this.store.__pushPromise(promise, this.queryKey)
     }
-    this.promise.then(
+    promise = promise.then((data: any) => {
+      // cache query and response
+      if (this.fetchPolicy !== "no-cache") {
+        this.store.__cacheResponse(this.queryKey, data)
+      }
+      return this.options.raw ? data : this.store.merge(data)
+    })
+    this.promise = promise
+    promise.then(
       action((data: any) => {
         this.loading = false
         this.data = data
@@ -133,7 +136,7 @@ export class Query<T = unknown> implements PromiseLike<T> {
   }
 
   private useCachedResults() {
-    const cached = this.store.__queryCache.get(this.cacheKey)
+    const cached = this.store.__queryCache.get(this.queryKey)
     this.data = this.options.raw
       ? cached
       : this.store.merge(this.store.deflate(cached))

--- a/src/react.tsx
+++ b/src/react.tsx
@@ -30,7 +30,7 @@ export async function getDataFromTree<STORE extends typeof MSTGQLStore.Type>(
     if (client.__promises.size === 0) {
       return html
     }
-    await Promise.all(client.__promises)
+    await Promise.all(client.__promises.values())
   }
 }
 

--- a/tests/lib/todos/todostore.test.js
+++ b/tests/lib/todos/todostore.test.js
@@ -96,8 +96,9 @@ describe("todos.graphql tests", () => {
 
     // Then, the 2 todos mocked above should be loaded and merged
     const promise = store.queryTodos()
-    expect(store.__promises.size).toBe(0)
+    expect(store.__promises.size).toBe(1)
     await promise
+    expect(store.__promises.size).toBe(0)
     expect(store.todos.size).toBe(2)
     expect(store.todos.get("a").text).toBe("Initially loaded todo, now updated")
 
@@ -139,7 +140,7 @@ describe("todos.graphql tests", () => {
     store.queryTodos()
     expect(store.__promises.size).toBe(1)
     expect(store.todos.size).toBe(1)
-    await Promise.all(store.__promises)
+    await Promise.all(store.__promises.values())
     expect(store.todos.size).toBe(2)
     const todoB = store.todos.get("b")
     expect(todoB.text).toBe("Another todo")


### PR DESCRIPTION
As per @mweststrate's comment at https://github.com/zenflow/mst-gql/blob/4f37e7444775aeafb9b883bb2e17933937109607/src/Query.ts#L46
> // possible optimization: merge double in-flight requests

This is an important optimization when rendering a bunch of components that declare their own data dependencies, since dependencies are commonly repeated. For example, in examples/5-nextjs, in the "Todos" list, where todos are assigned to either Rick or Morty, when loading we want to request data for each of those `User`s a maximum of once. With the current code in master, when loading we have one user request per todo and therefore some duplicate requests.

I changed the public API of `RootStore` by removing `pushPromise` & `unpushPromise` and replacing them with a private `__pushPromise`. I think it makes sense to be private, and I think it makes sense for it (`__pushPromise`) to handle unpushing the promise after it settles, since it's something that a caller will always need to happen. Let me know if you disagree with either statement.

/cc @chrisdrackett @mattiasewers 


