### PR TITLE
Drop "raw" option for queries & keep __queryCache normalized (#99)

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ async function preload() {
 
 # 🍿 In-depth store semantics 🍿
 
-mst-gql generates model types for every object type in your graphql definition. (Except for those excluded using the `excludes` flag). For any query or mutation that is executed by the store, the returned data will be automatically, and recursively parsed into those generated MST models (unless the `raw` flag is set). This means that for any query, you get a 'rich' object back. Finding the right model type is done based on the GraphQL meta field `__typename`, so make sure to include it in your graphql queries!
+mst-gql generates model types for every object type in your graphql definition. (Except for those excluded using the `excludes` flag). For any query or mutation that is executed by the store, the returned data will be automatically, and recursively parsed into those generated MST models. This means that for any query, you get a 'rich' object back. Finding the right model type is done based on the GraphQL meta field `__typename`, so make sure to include it in your graphql queries!
 
 The philosophy behind MST / mst-gql is that every 'business concept' should exist only once in the client state, so that there is only one source of truth for every message, usage, order, product etc. that you are holding in memory. To achieve this, it is recommended that every uniquely identifyable concept in your application, does have an `id` field of the graphQL `ID` type. By default, any object types for which this is true, is considered to be a "root type".
 
@@ -428,10 +428,8 @@ Makes a graphQL request to the backend. The result of the query is by default au
 
 - The `query` parameter can be a string, or a `graphql-tag` based query.
 - Variables are the raw JSON data structures that should be send as variable substitutions to the backend. This parameter is optional.
-- Options is an optional [QueryOptions](#queryoptions) object. The defaults are `raw: false` and `fetchPolicy: "cache-and-network"`
+- Options is an optional [QueryOptions](#queryoptions) object. The defaults are fetchPolicy: "cache-and-network"`
 - The method returns a [`Query`](#query-object) that can be inspected to keep track of the request progress.
-
-Use `raw: true` and `fetchPolicy: no-cache` if you want to make a completely side effect free one time request to the backend that gives raw data back.
 
 Be sure to at least select `__typename` and `id` in the result selector, so that mst-gql can normalize the data.
 
@@ -510,14 +508,11 @@ Beyond that, the the following top-level exports are exposed from each model fil
 
 ```
 export interface QueryOptions {
-  raw?: boolean
   fetchPolicy?: FetchPolicy
 }
 ```
 
 See [Query caching](#query-caching) for more details on `fetchPolicy`. Default: `"cache-and-network"`
-
-The `raw` field indicates whether the result set should parsed into model instances, or returned as raw JSOn
 
 ## `createHttpClient(url: string, options: HttpClientOptions = {})`
 
@@ -612,7 +607,6 @@ It accepts zero, one or 2 arguments:
   - A callback, that will receive as first argument the `store`, and should return a `Query` object. The callback will be invoked when the component is rendered for the first time, and is a great way to delegate the query logic itself to the store. This is the recommend approach. For example `store => store.queryAllMessages()`
 - `options`, an object which can specify further options, such as
   - `variables`: The variables to be substituted into the graphQL query (only used if the query is specified as graphql tag or string!)
-  - `raw`: See the raw option of queries
   - `fetchPolicy`: See fetch policy
   - `store`: This can be used to customize which store should be used. This can be pretty convenient for testing, as it means that no Provider needs to be used.
 

--- a/src/react.tsx
+++ b/src/react.tsx
@@ -40,18 +40,15 @@ function normalizeQuery<STORE extends typeof MSTGQLStore.Type, DATA>(
   {
     variables,
     fetchPolicy = "cache-and-network",
-    raw = false
   }: {
     variables?: any
     fetchPolicy?: FetchPolicy
-    raw?: boolean
   }
 ): Query<DATA> {
   if (typeof query === "function") return query(store)
   if (query instanceof Query) return query
   return store.query(query, variables, {
     fetchPolicy: fetchPolicy,
-    raw: raw
   })
 }
 
@@ -59,7 +56,6 @@ export type UseQueryHookOptions<STORE> = {
   store?: STORE
   variables?: any
   fetchPolicy?: FetchPolicy
-  raw?: boolean
 }
 
 export type UseQueryHookResult<STORE, DATA> = {
@@ -105,7 +101,7 @@ export function createUseQueryHook<STORE extends typeof MSTGQLStore.Type>(
     React.useEffect(() => {
       if (!queryIn || typeof queryIn === "function") return // ignore changes to initializer func
       setQueryHelper(queryIn)
-    }, [queryIn, opts.raw, opts.fetchPolicy, JSON.stringify(opts.variables)]) // TODO: use a decent deep equal
+    }, [queryIn, opts.fetchPolicy, JSON.stringify(opts.variables)]) // TODO: use a decent deep equal
 
     return {
       store,

--- a/tests/lib/todos/__snapshots__/todostore.test.js.snap
+++ b/tests/lib/todos/__snapshots__/todostore.test.js.snap
@@ -28,15 +28,11 @@ complete
         "todos": Array [
           Object {
             "__typename": "Todo",
-            "complete": true,
             "id": "a",
-            "text": "Initially loaded todo, now updated",
           },
           Object {
             "__typename": "Todo",
-            "complete": false,
             "id": "b",
-            "text": "Another todo",
           },
         ],
       },

--- a/tests/lib/todos/__snapshots__/todostore.test.js.snap
+++ b/tests/lib/todos/__snapshots__/todostore.test.js.snap
@@ -13,3 +13,48 @@ Object {
   },
 }
 `;
+
+exports[`todos.graphql tests it should be able to instantiate store and load initial data 3`] = `
+Object {
+  "__queryCache": Object {
+    "query todos { todos {
+        __typename
+id
+text
+complete
+
+      } }undefined": Object {
+      "data": Object {
+        "todos": Array [
+          Object {
+            "__typename": "Todo",
+            "complete": true,
+            "id": "a",
+            "text": "Initially loaded todo, now updated",
+          },
+          Object {
+            "__typename": "Todo",
+            "complete": false,
+            "id": "b",
+            "text": "Another todo",
+          },
+        ],
+      },
+    },
+  },
+  "todos": Object {
+    "a": Object {
+      "__typename": "Todo",
+      "complete": true,
+      "id": "a",
+      "text": "Initially loaded todo, now updated",
+    },
+    "b": Object {
+      "__typename": "Todo",
+      "complete": false,
+      "id": "b",
+      "text": "Another todo",
+    },
+  },
+}
+`;

--- a/tests/lib/todos/todostore.test.js
+++ b/tests/lib/todos/todostore.test.js
@@ -100,6 +100,7 @@ describe("todos.graphql tests", () => {
     await promise
     expect(store.todos.size).toBe(2)
     expect(store.todos.get("a").text).toBe("Initially loaded todo, now updated")
+    expect(store.toJSON()).toMatchSnapshot()
 
     const todoB = store.todos.get("b")
     expect(todoB.text).toBe("Another todo")


### PR DESCRIPTION
This is how I would like to resolve #99 (follow-up to issue #91 / PR #97).

Notice that none of the examples needed to be changed 😃 

I added a new snapshot test before making the changes, so you can observe the effect of this optimization via the changes to the snapshot in 34cb585

/cc @chrisdrackett @mattiasewers