### PR TITLE
Work on support for abstract (union or interface) types

### DIFF
--- a/generator/generate.js
+++ b/generator/generate.js
@@ -377,7 +377,9 @@ ${generateFragments(name, primitiveFields, nonPrimitiveFields)}
       const isSelf = fieldType.name === currentType
 
       // this type is not going to be handled by mst-gql, store as frozen
-      if (!knownTypes.includes(fieldType.name)) return `types.frozen()`
+      if (!knownTypes.includes(fieldType.name)) {
+        return `types.frozen()`
+      }
 
       // import the type
       const modelType = fieldType.name + "Model"
@@ -410,6 +412,10 @@ ${generateFragments(name, primitiveFields, nonPrimitiveFields)}
 
       const interfaceOrUnionType = interfaceAndUnionTypes.get(fieldType.name)
       const mstUnionArgs = interfaceOrUnionType.ofTypes.map(t => {
+        if (!knownTypes.includes(t.name)) {
+          return `types.frozen()`
+        }
+
         // Note that members of a union type need to be concrete object types;
         // you can't create a union type out of interfaces or other unions.
         const subTypeClassName = t.name + "Model"

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -638,12 +638,16 @@ ${rootTypes
         if (returnType.kind === "OBJECT" && excludes.includes(returnType.name))
           return ""
         // TODO: probably we will need to support input object types soon
-        if (returnType.kind !== "OBJECT") {
+        const isReturnTypeAnObject =
+          returnType.kind === "OBJECT" ||
+          returnType.kind === "UNION" ||
+          returnType.kind === "INTERFACE"
+        // TODO: for now, we only generate queries for those queries that return objects
+        if (!isReturnTypeAnObject) {
           console.warn(
             `Skipping generation of query '${name}', its return type is not yet understood. PR is welcome`
           )
-          // log(returnType)
-          return "" // TODO: for now, we only generate queries for those queries that return objects
+          return ""
         }
 
         const tsType =

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -392,7 +392,9 @@ ${generateFragments(name, primitiveFields, nonPrimitiveFields)}
       } => ${fieldType.name}Model)`
 
       // this object is not a root type, so assume composition relationship
-      if (!rootTypes.includes(fieldType.name)) return realType
+      if (!rootTypes.includes(fieldType.name)) {
+        return realType
+      }
 
       // the target is a root type, store a reference
       refs.push([fieldName, fieldType.name])
@@ -416,10 +418,20 @@ ${generateFragments(name, primitiveFields, nonPrimitiveFields)}
           addImport(subTypeClassName, subTypeClassName)
         }
         const isSelf = fieldType.name === currentType
+
         // always using late prevents potential circular dependency issues between files
-        return `types.late(()${
+        const realType = `types.late(()${
           isSelf && format === "ts" ? ": any" : ""
         } => ${subTypeClassName})`
+
+        // this object is not a root type, so assume composition relationship
+        if (!rootTypes.includes(t.name)) {
+          return realType
+        }
+
+        // the target is a root type, store a reference
+        refs.push([fieldName, fieldType.name, t.name])
+        return `MSTGQLRef(${realType})`
       })
       return `types.union(${mstUnionArgs.join(", ")})`
     }

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -553,6 +553,14 @@ ${objectTypes
   .join("")}
 ${enumTypes
   .map(t => `\nimport { ${t} } from "./${t}Enum${importPostFix}"`)
+  .join("")}\
+${[...interfaceAndUnionTypes.keys()]
+  .map(
+    t =>
+      `\nimport { ${toFirstLower(
+        t
+      )}ModelPrimitives, ${t}ModelSelector } from "./${t}ModelSelector${importPostFix}"`
+  )
   .join("")}
 ${ifTS(
   inputTypes

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -392,7 +392,7 @@ ${generateFragments(name, primitiveFields, nonPrimitiveFields)}
       } => ${fieldType.name}Model)`
 
       // this object is not a root type, so assume composition relationship
-      if (!isSelf && !rootTypes.includes(fieldType.name)) return realType
+      if (!rootTypes.includes(fieldType.name)) return realType
 
       // the target is a root type, store a reference
       refs.push([fieldName, fieldType.name])

--- a/tests/generator/__snapshots__/generate.test.js.snap
+++ b/tests/generator/__snapshots__/generate.test.js.snap
@@ -423,6 +423,7 @@ import { userModelPrimitives, UserModelSelector } from \\"./UserModel.base\\"
 import { OrganizationModel, OrganizationModelType } from \\"./OrganizationModel\\"
 import { organizationModelPrimitives, OrganizationModelSelector } from \\"./OrganizationModel.base\\"
 
+import { ownerModelPrimitives, OwnerModelSelector } from \\"./OwnerModelSelector\\"
 
 /**
 * Store, managing, among others, all the objects received through graphQL
@@ -739,6 +740,7 @@ import { movieModelPrimitives, MovieModelSelector } from \\"./MovieModel.base\\"
 import { BookModel, BookModelType } from \\"./BookModel\\"
 import { bookModelPrimitives, BookModelSelector } from \\"./BookModel.base\\"
 
+import { searchItemModelPrimitives, SearchItemModelSelector } from \\"./SearchItemModelSelector\\"
 
 /**
 * Store, managing, among others, all the objects received through graphQL

--- a/tests/lib/abstractTypes/abstractTypes.test.js
+++ b/tests/lib/abstractTypes/abstractTypes.test.js
@@ -207,4 +207,49 @@ describe("Abstract types tests", () => {
     const mobxRepo = repos.get("b")
     expect(mobxRepo.owner.name).toBe("Mobx")
   })
+
+  test("as a lib user i want to use methods for queries that have abstract return types", async () => {
+    const mockRepoQuery = query => {
+      validateQuery(query.toString())
+
+      return {
+        getAllOwners: [
+          {
+            __typename: "User",
+            id: "chuck",
+            name: "Chuck Norris",
+            avatar: "chuck-norris.png"
+          },
+          {
+            __typename: "Organization",
+            id: "mobx",
+            name: "Mobx",
+            logo: "mobx.png"
+          }
+        ]
+      }
+    }
+    mockResponses = [mockRepoQuery]
+
+    const {
+      ownerModelPrimitives,
+      userModelPrimitives,
+      organizationModelPrimitives
+    } = models
+    const { getAllOwners } = await store.queryGetAllOwners(
+      {},
+      ownerModelPrimitives
+        .user(userModelPrimitives)
+        .organization(organizationModelPrimitives)
+    )
+    const [chuckNorrisUser, mobxOrganization] = getAllOwners
+
+    expect(chuckNorrisUser).toBe(store.users.get("chuck"))
+    expect(chuckNorrisUser.name).toBe("Chuck Norris")
+    expect(chuckNorrisUser.avatar).toBe("chuck-norris.png")
+
+    expect(mobxOrganization).toBe(store.organizations.get("mobx"))
+    expect(mobxOrganization.name).toBe("Mobx")
+    expect(mobxOrganization.logo).toBe("mobx.png")
+  })
 })

--- a/tests/lib/abstractTypes/abstractTypes.test.js
+++ b/tests/lib/abstractTypes/abstractTypes.test.js
@@ -28,7 +28,7 @@ describe("Abstract types tests", () => {
   beforeAll(() => {
     const files = scaffold(schemaContents, {
       format: "js",
-      roots: ["SearchResult", "Repo"]
+      roots: ["Repo"]
     })
     writeFiles(__dirname + "/models", files, "js", false)
     models = require("./models")
@@ -74,12 +74,11 @@ describe("Abstract types tests", () => {
     mockResponses = [mockSearchQuery]
 
     const { searchResultModelPrimitives, searchItemModelPrimitives } = models
-    await store.querySearch(
+    const { search: searchResults } = await store.querySearch(
       { text: "noot" },
       searchResultModelPrimitives.items(searchItemModelPrimitives)
     )
 
-    const searchResults = store.searchresults.get()
     expect(searchResults.inputQuery).toBe("noot")
     const items = searchResults.items
     expect(items).toHaveLength(2)

--- a/tests/lib/abstractTypes/abstractTypes.test.js
+++ b/tests/lib/abstractTypes/abstractTypes.test.js
@@ -28,7 +28,7 @@ describe("Abstract types tests", () => {
   beforeAll(() => {
     const files = scaffold(schemaContents, {
       format: "js",
-      roots: ["Repo"]
+      roots: ["Repo", "User", "Organization"]
     })
     writeFiles(__dirname + "/models", files, "js", false)
     models = require("./models")

--- a/tests/lib/abstractTypes/abstractTypes.test.js
+++ b/tests/lib/abstractTypes/abstractTypes.test.js
@@ -53,23 +53,21 @@ describe("Abstract types tests", () => {
       validateQuery(query.toString())
 
       return {
-        data: {
-          search: {
-            __typename: "SearchResult",
-            inputQuery: "noot",
-            items: [
-              {
-                __typename: "Movie",
-                searchPreviewText: "Aap noot mies",
-                director: "Steven Spielberg"
-              },
-              {
-                __typename: "Book",
-                searchPreviewText: "Blub noot",
-                author: "Ernest Hemingway"
-              }
-            ]
-          }
+        search: {
+          __typename: "SearchResult",
+          inputQuery: "noot",
+          items: [
+            {
+              __typename: "Movie",
+              searchPreviewText: "Aap noot mies",
+              director: "Steven Spielberg"
+            },
+            {
+              __typename: "Book",
+              searchPreviewText: "Blub noot",
+              author: "Ernest Hemingway"
+            }
+          ]
         }
       }
     }
@@ -98,28 +96,26 @@ describe("Abstract types tests", () => {
       validateQuery(query.toString())
 
       return {
-        data: {
-          getAllRepos: [
-            {
-              __typename: "Repo",
-              id: "a",
-              owner: {
-                __typename: "User",
-                id: "y",
-                name: "Chuck Norris"
-              }
-            },
-            {
-              __typename: "Repo",
-              id: "b",
-              owner: {
-                __typename: "Organization",
-                id: "z",
-                name: "Mobx"
-              }
+        getAllRepos: [
+          {
+            __typename: "Repo",
+            id: "a",
+            owner: {
+              __typename: "User",
+              id: "y",
+              name: "Chuck Norris"
             }
-          ]
-        }
+          },
+          {
+            __typename: "Repo",
+            id: "b",
+            owner: {
+              __typename: "Organization",
+              id: "z",
+              name: "Mobx"
+            }
+          }
+        ]
       }
     }
     mockResponses = [mockRepoQuery]
@@ -166,10 +162,8 @@ describe("Abstract types tests", () => {
       addedRepos.push(repo)
 
       return {
-        data: {
-          addRepo: {
-            ...repo
-          }
+        addRepo: {
+          ...repo
         }
       }
     }
@@ -178,9 +172,7 @@ describe("Abstract types tests", () => {
       validateQuery(query.toString())
 
       return {
-        data: {
-          getAllRepos: addedRepos
-        }
+        getAllRepos: addedRepos
       }
     }
 

--- a/tests/lib/abstractTypes/models/RepoModel.base.js
+++ b/tests/lib/abstractTypes/models/RepoModel.base.js
@@ -2,7 +2,7 @@
 /* eslint-disable */
 
 import { types } from "mobx-state-tree"
-import { QueryBuilder } from "mst-gql"
+import { MSTGQLRef, QueryBuilder } from "mst-gql"
 import { ModelBase } from "./ModelBase"
 import { OrganizationModel } from "./OrganizationModel"
 import { OwnerModelSelector } from "./OwnerModelSelector"
@@ -18,7 +18,7 @@ export const RepoModelBase = ModelBase
   .props({
     __typename: types.optional(types.literal("Repo"), "Repo"),
     id: types.identifier,
-    owner: types.maybeNull(types.union(types.late(() => UserModel), types.late(() => OrganizationModel))),
+    owner: types.maybeNull(types.union(MSTGQLRef(types.late(() => UserModel)), MSTGQLRef(types.late(() => OrganizationModel)))),
   })
   .views(self => ({
     get store() {

--- a/tests/lib/abstractTypes/models/RootStore.base.js
+++ b/tests/lib/abstractTypes/models/RootStore.base.js
@@ -16,6 +16,8 @@ import { userModelPrimitives, UserModelSelector } from "./UserModel.base"
 import { OrganizationModel } from "./OrganizationModel"
 import { organizationModelPrimitives, OrganizationModelSelector } from "./OrganizationModel.base"
 
+import { searchItemModelPrimitives, SearchItemModelSelector } from "./SearchItemModelSelector"
+import { ownerModelPrimitives, OwnerModelSelector } from "./OwnerModelSelector"
 
 /**
 * Store, managing, among others, all the objects received through graphQL

--- a/tests/lib/abstractTypes/models/RootStore.base.js
+++ b/tests/lib/abstractTypes/models/RootStore.base.js
@@ -22,9 +22,11 @@ import { organizationModelPrimitives, OrganizationModelSelector } from "./Organi
 */
 export const RootStoreBase = MSTGQLStore
   .named("RootStore")
-  .extend(configureStoreMixin([['SearchResult', () => SearchResultModel], ['Movie', () => MovieModel], ['Book', () => BookModel], ['Repo', () => RepoModel], ['User', () => UserModel], ['Organization', () => OrganizationModel]], ['Repo']))
+  .extend(configureStoreMixin([['SearchResult', () => SearchResultModel], ['Movie', () => MovieModel], ['Book', () => BookModel], ['Repo', () => RepoModel], ['User', () => UserModel], ['Organization', () => OrganizationModel]], ['Repo', 'User', 'Organization']))
   .props({
-    repos: types.optional(types.map(types.late(() => RepoModel)), {})
+    repos: types.optional(types.map(types.late(() => RepoModel)), {}),
+    users: types.optional(types.map(types.late(() => UserModel)), {}),
+    organizations: types.optional(types.map(types.late(() => OrganizationModel)), {})
   })
   .actions(self => ({
     querySearch(variables, resultSelector = searchResultModelPrimitives.toString(), options = {}) {

--- a/tests/lib/abstractTypes/models/RootStore.base.js
+++ b/tests/lib/abstractTypes/models/RootStore.base.js
@@ -39,6 +39,11 @@ export const RootStoreBase = MSTGQLStore
         ${typeof resultSelector === "function" ? resultSelector(new RepoModelSelector()).toString() : resultSelector}
       } }`, variables, options)
     },
+    queryGetAllOwners(variables, resultSelector = ownerModelPrimitives.toString(), options = {}) {
+      return self.query(`query getAllOwners { getAllOwners {
+        ${typeof resultSelector === "function" ? resultSelector(new OwnerModelSelector()).toString() : resultSelector}
+      } }`, variables, options)
+    },
     mutateAddRepo(variables, resultSelector = repoModelPrimitives.toString(), optimisticUpdate) {
       return self.mutate(`mutation addRepo($name: String!, $ownerName: String!, $avatar: String, $logo: String) { addRepo(name: $name, ownerName: $ownerName, avatar: $avatar, logo: $logo) {
         ${typeof resultSelector === "function" ? resultSelector(new RepoModelSelector()).toString() : resultSelector}

--- a/tests/lib/abstractTypes/models/RootStore.base.js
+++ b/tests/lib/abstractTypes/models/RootStore.base.js
@@ -22,9 +22,8 @@ import { organizationModelPrimitives, OrganizationModelSelector } from "./Organi
 */
 export const RootStoreBase = MSTGQLStore
   .named("RootStore")
-  .extend(configureStoreMixin([['SearchResult', () => SearchResultModel], ['Movie', () => MovieModel], ['Book', () => BookModel], ['Repo', () => RepoModel], ['User', () => UserModel], ['Organization', () => OrganizationModel]], ['SearchResult', 'Repo']))
+  .extend(configureStoreMixin([['SearchResult', () => SearchResultModel], ['Movie', () => MovieModel], ['Book', () => BookModel], ['Repo', () => RepoModel], ['User', () => UserModel], ['Organization', () => OrganizationModel]], ['Repo']))
   .props({
-    searchresults: types.optional(types.map(types.late(() => SearchResultModel)), {}),
     repos: types.optional(types.map(types.late(() => RepoModel)), {})
   })
   .actions(self => ({

--- a/tests/lib/abstractTypes/schema.graphql
+++ b/tests/lib/abstractTypes/schema.graphql
@@ -1,6 +1,7 @@
 type Query {
   search(text: String!): SearchResult!
   getAllRepos: [Repo]
+  getAllOwners: [Owner]
 }
 type Mutation {
   addRepo(name: String!, ownerName: String!, avatar: String, logo: String): Repo


### PR DESCRIPTION
## Primary fix

[generate] Use MSTGQLRef /w root types also for abstract type fields (b2f3760)

Currently in master, the generator uses MSTGQLRef around root types only when that root type is appearing as a simple/concrete field type. When the root type is appearing as a part of an abstract (interface or union) field type, MSTGQLRef is not used.

MSTGQLRef *always* needs to be used with root types, because the mst nodes of root types are already living in their dedicated prop on the root store. We will otherwise get errors like `[mobx-state-tree] Cannot add an object to a state tree if it is already part of the same or another state tree. Tried to assign an object to '/owner', but it lives already at '/users/y'` when loading query data.

*(edited)* For a concrete example, see `tests/lib/abstractTypes` where the `Repo` type has an `owner` field with the (abstract) interface type `Owner` which is implemented by (concrete) types `User` and `Organization`...

this:

https://github.com/mobxjs/mst-gql/blob/ad4682613f9d11c4e64323f302432ebc17894273/tests/lib/abstractTypes/models/RepoModel.base.js#L21

becomes:

https://github.com/mobxjs/mst-gql/blob/4e9c1ee8f31363553a297c14ee9f1e47ac1270ae/tests/lib/abstractTypes/models/RepoModel.base.js#L21



Note: You can see the tests failing with the aforementioned error at commit 47ecbe2 `[tests/lib/abstractTypes] Add User & Organization to root types`.

## Other changes 

Fixed defined root types in `tests/lib/abstractTypes`. Removed SearchResult (4ffa1f4) since it doesn't have an ID and thus doesn't qualify as a root type. Added User & Organization (47ecbe2), since they can qualify as a root type, and that is probably what the user would want it to be

I noticed we are preventing object fields from being a reference to another object of the same type, which can't be right, so I fixed that with commit c1a41e4 `[generate] Allow object field to be *reference* to object's own type`.

I also noticed that, similar to the main issue I was fixing, we are forgetting to do something for abstract field types that we are doing for simple/concrete field types. With commit da66cb1 `[generate] Use frozen for unknown types also for abstract type fields` we consistently use `types.frozen()` for unknown types.