### PR TITLE
Restore missing header/preable in generated XXXModelSelector files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,6 +12,7 @@ __snapshots__
 **/models/reactUtils.*
 **/models/*.base.*
 **/models/*Enum.*
+**/models/*ModelSelector.*
 
 # yarn
 yarn.lock

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Tip: Note that API descriptions found in the graphQL endpoint will generally end
 
 After running the scaffolder, a bunch of files will be generated in the `src/models/` directory of your project (or whatever path your provided):
 
-*(Files marked ✏ can and should be edited. They won't be overwritten when you scaffold unless you use the `force` option.)*
+_(Files marked ✏ can and should be edited. They won't be overwritten when you scaffold unless you use the `force` option.)_
 
 - `index` - A barrel file that exposes all interesting things generated
 - `RootStore.base` - A mobx-state-tree store that acts as a graphql client. Provides the following:

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -275,8 +275,7 @@ ${generateFragments(name, primitiveFields, nonPrimitiveFields)}
       })
 
     let contents = header + "\n\n"
-    contents = 'import { QueryBuilder } from "mst-gql"\n'
-
+    contents += 'import { QueryBuilder } from "mst-gql"\n'
     contents += printRelativeImports(imports)
     contents += generateFragments(
       type.name,

--- a/tests/generator/__snapshots__/generate.test.js.snap
+++ b/tests/generator/__snapshots__/generate.test.js.snap
@@ -236,7 +236,11 @@ export const RepoModel = RepoModelBase
   ],
   Array [
     "OwnerModelSelector",
-    "import { QueryBuilder } from \\"mst-gql\\"
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+import { QueryBuilder } from \\"mst-gql\\"
 import { OrganizationModelSelector } from \\"./OrganizationModel.base\\"
 import { UserModelSelector } from \\"./UserModel.base\\"
 
@@ -553,7 +557,11 @@ export const SearchResultModel = SearchResultModelBase
   ],
   Array [
     "SearchItemModelSelector",
-    "import { QueryBuilder } from \\"mst-gql\\"
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+import { QueryBuilder } from \\"mst-gql\\"
 import { BookModelSelector, bookModelPrimitives } from \\"./BookModel.base\\"
 import { MovieModelSelector, movieModelPrimitives } from \\"./MovieModel.base\\"
 

--- a/tests/lib/abstractTypes/models/OwnerModelSelector.js
+++ b/tests/lib/abstractTypes/models/OwnerModelSelector.js
@@ -1,3 +1,6 @@
+/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+
 import { QueryBuilder } from "mst-gql"
 import { OrganizationModelSelector } from "./OrganizationModel.base"
 import { UserModelSelector } from "./UserModel.base"

--- a/tests/lib/abstractTypes/models/OwnerModelSelector.js
+++ b/tests/lib/abstractTypes/models/OwnerModelSelector.js
@@ -3,22 +3,10 @@ import { OrganizationModelSelector } from "./OrganizationModel.base"
 import { UserModelSelector } from "./UserModel.base"
 
 export class OwnerModelSelector extends QueryBuilder {
-  get id() {
-    return this.__attr(`id`)
-  }
-  get name() {
-    return this.__attr(`name`)
-  }
-  user(builder) {
-    return this.__inlineFragment(`User`, UserModelSelector, builder)
-  }
-  organization(builder) {
-    return this.__inlineFragment(
-      `Organization`,
-      OrganizationModelSelector,
-      builder
-    )
-  }
+  get id() { return this.__attr(`id`) }
+  get name() { return this.__attr(`name`) }
+  user(builder) { return this.__inlineFragment(`User`, UserModelSelector, builder) }
+  organization(builder) { return this.__inlineFragment(`Organization`, OrganizationModelSelector, builder) }
 }
 export function selectFromOwner() {
   return new OwnerModelSelector()

--- a/tests/lib/abstractTypes/models/SearchItemModelSelector.js
+++ b/tests/lib/abstractTypes/models/SearchItemModelSelector.js
@@ -1,3 +1,6 @@
+/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+
 import { QueryBuilder } from "mst-gql"
 import { BookModelSelector, bookModelPrimitives } from "./BookModel.base"
 import { MovieModelSelector, movieModelPrimitives } from "./MovieModel.base"

--- a/tests/lib/abstractTypes/models/SearchItemModelSelector.js
+++ b/tests/lib/abstractTypes/models/SearchItemModelSelector.js
@@ -3,18 +3,12 @@ import { BookModelSelector, bookModelPrimitives } from "./BookModel.base"
 import { MovieModelSelector, movieModelPrimitives } from "./MovieModel.base"
 
 export class SearchItemModelSelector extends QueryBuilder {
-  movie(builder) {
-    return this.__inlineFragment(`Movie`, MovieModelSelector, builder)
-  }
-  book(builder) {
-    return this.__inlineFragment(`Book`, BookModelSelector, builder)
-  }
+  movie(builder) { return this.__inlineFragment(`Movie`, MovieModelSelector, builder) }
+  book(builder) { return this.__inlineFragment(`Book`, BookModelSelector, builder) }
 }
 export function selectFromSearchItem() {
   return new SearchItemModelSelector()
 }
 
 // provides all primitive fields of union member types combined together
-export const searchItemModelPrimitives = selectFromSearchItem()
-  .movie(movieModelPrimitives)
-  .book(bookModelPrimitives)
+export const searchItemModelPrimitives = selectFromSearchItem().movie(movieModelPrimitives).book(bookModelPrimitives)


### PR DESCRIPTION
- 5f24785 `Add XXXModelSelector module to prettier ignore` Same commit from https://github.com/mobxjs/mst-gql/pull/114#issuecomment-536592942
- 5583647 `Restore missing header/preable in generated XXXModelSelector files` Looks like [a little typo in generator.js](https://github.com/mobxjs/mst-gql/pull/115/files#diff-afe7a4325834df8a33abce88b6e9d561) was preventing these files from having the normal header for generated files
