### PR TITLE
Integrate new ModelBase file (#106) in rest of examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Tip: Note that API descriptions found in the graphQL endpoint will generally end
 
 After running the scaffolder, a bunch of files will be generated in the `src/models/` directory of your project (or whatever path your provided):
 
-*(Files marked ✏ can and should be edited. They won't be overwritten when you scaffold unless you use the `force` option.)*
+_(Files marked ✏ can and should be edited. They won't be overwritten when you scaffold unless you use the `force` option.)_
 
 - `index` - A barrel file that exposes all interesting things generated
 - `RootStore.base` - A mobx-state-tree store that acts as a graphql client. Provides the following:

--- a/examples/1-getting-started/src/app/models/ModelBase.ts
+++ b/examples/1-getting-started/src/app/models/ModelBase.ts
@@ -1,0 +1,3 @@
+import { MSTGQLObject } from "mst-gql"
+
+export const ModelBase = MSTGQLObject

--- a/examples/1-getting-started/src/app/models/TodoModel.base.ts
+++ b/examples/1-getting-started/src/app/models/TodoModel.base.ts
@@ -3,7 +3,8 @@
 /* tslint:disable */
 
 import { types } from "mobx-state-tree"
-import { MSTGQLObject, QueryBuilder } from "mst-gql"
+import { QueryBuilder } from "mst-gql"
+import { ModelBase } from "./ModelBase"
 import { RootStoreType } from "./index"
 
 
@@ -11,7 +12,7 @@ import { RootStoreType } from "./index"
  * TodoBase
  * auto generated base class for the model TodoModel.
  */
-export const TodoModelBase = MSTGQLObject
+export const TodoModelBase = ModelBase
   .named('Todo')
   .props({
     __typename: types.optional(types.literal("Todo"), "Todo"),

--- a/examples/2-scaffolding/src/models/AttackModel.base.ts
+++ b/examples/2-scaffolding/src/models/AttackModel.base.ts
@@ -3,7 +3,8 @@
 /* tslint:disable */
 
 import { types } from "mobx-state-tree"
-import { MSTGQLObject, QueryBuilder } from "mst-gql"
+import { QueryBuilder } from "mst-gql"
+import { ModelBase } from "./ModelBase"
 import { RootStoreType } from "./index"
 
 
@@ -13,7 +14,7 @@ import { RootStoreType } from "./index"
  *
  * Represents a Pokémon's attack types
  */
-export const AttackModelBase = MSTGQLObject
+export const AttackModelBase = ModelBase
   .named('Attack')
   .props({
     __typename: types.optional(types.literal("Attack"), "Attack"),

--- a/examples/2-scaffolding/src/models/ModelBase.ts
+++ b/examples/2-scaffolding/src/models/ModelBase.ts
@@ -1,0 +1,3 @@
+import { MSTGQLObject } from "mst-gql"
+
+export const ModelBase = MSTGQLObject

--- a/examples/2-scaffolding/src/models/PokemonAttackModel.base.ts
+++ b/examples/2-scaffolding/src/models/PokemonAttackModel.base.ts
@@ -3,7 +3,8 @@
 /* tslint:disable */
 
 import { types } from "mobx-state-tree"
-import { MSTGQLObject, MSTGQLRef, QueryBuilder } from "mst-gql"
+import { MSTGQLRef, QueryBuilder } from "mst-gql"
+import { ModelBase } from "./ModelBase"
 import { AttackModel } from "./AttackModel"
 import { AttackModelSelector } from "./AttackModel.base"
 import { RootStoreType } from "./index"
@@ -15,7 +16,7 @@ import { RootStoreType } from "./index"
  *
  * Represents a Pokémon's attack types
  */
-export const PokemonAttackModelBase = MSTGQLObject
+export const PokemonAttackModelBase = ModelBase
   .named('PokemonAttack')
   .props({
     __typename: types.optional(types.literal("PokemonAttack"), "PokemonAttack"),

--- a/examples/2-scaffolding/src/models/PokemonDimensionModel.base.ts
+++ b/examples/2-scaffolding/src/models/PokemonDimensionModel.base.ts
@@ -3,7 +3,8 @@
 /* tslint:disable */
 
 import { types } from "mobx-state-tree"
-import { MSTGQLObject, QueryBuilder } from "mst-gql"
+import { QueryBuilder } from "mst-gql"
+import { ModelBase } from "./ModelBase"
 import { RootStoreType } from "./index"
 
 
@@ -13,7 +14,7 @@ import { RootStoreType } from "./index"
  *
  * Represents a Pokémon's dimensions
  */
-export const PokemonDimensionModelBase = MSTGQLObject
+export const PokemonDimensionModelBase = ModelBase
   .named('PokemonDimension')
   .props({
     __typename: types.optional(types.literal("PokemonDimension"), "PokemonDimension"),

--- a/examples/2-scaffolding/src/models/PokemonEvolutionRequirementModel.base.ts
+++ b/examples/2-scaffolding/src/models/PokemonEvolutionRequirementModel.base.ts
@@ -3,7 +3,8 @@
 /* tslint:disable */
 
 import { types } from "mobx-state-tree"
-import { MSTGQLObject, QueryBuilder } from "mst-gql"
+import { QueryBuilder } from "mst-gql"
+import { ModelBase } from "./ModelBase"
 import { RootStoreType } from "./index"
 
 
@@ -13,7 +14,7 @@ import { RootStoreType } from "./index"
  *
  * Represents a Pokémon's requirement to evolve
  */
-export const PokemonEvolutionRequirementModelBase = MSTGQLObject
+export const PokemonEvolutionRequirementModelBase = ModelBase
   .named('PokemonEvolutionRequirement')
   .props({
     __typename: types.optional(types.literal("PokemonEvolutionRequirement"), "PokemonEvolutionRequirement"),

--- a/examples/2-scaffolding/src/models/PokemonModel.base.ts
+++ b/examples/2-scaffolding/src/models/PokemonModel.base.ts
@@ -3,7 +3,8 @@
 /* tslint:disable */
 
 import { types } from "mobx-state-tree"
-import { MSTGQLObject, MSTGQLRef, QueryBuilder } from "mst-gql"
+import { MSTGQLRef, QueryBuilder } from "mst-gql"
+import { ModelBase } from "./ModelBase"
 import { PokemonAttackModel } from "./PokemonAttackModel"
 import { PokemonAttackModelSelector } from "./PokemonAttackModel.base"
 import { PokemonDimensionModel } from "./PokemonDimensionModel"
@@ -20,7 +21,7 @@ import { RootStoreType } from "./index"
  *
  * Represents a Pokémon
  */
-export const PokemonModelBase = MSTGQLObject
+export const PokemonModelBase = ModelBase
   .named('Pokemon')
   .props({
     __typename: types.optional(types.literal("Pokemon"), "Pokemon"),

--- a/examples/3-twitter-clone/src/app/models/MessageModel.base.ts
+++ b/examples/3-twitter-clone/src/app/models/MessageModel.base.ts
@@ -3,7 +3,8 @@
 /* tslint:disable */
 
 import { types } from "mobx-state-tree"
-import { MSTGQLObject, MSTGQLRef, QueryBuilder } from "mst-gql"
+import { MSTGQLRef, QueryBuilder } from "mst-gql"
+import { ModelBase } from "./ModelBase"
 import { MessageModel } from "./MessageModel"
 import { UserModel } from "./UserModel"
 import { UserModelSelector } from "./UserModel.base"
@@ -14,7 +15,7 @@ import { RootStoreType } from "./index"
  * MessageBase
  * auto generated base class for the model MessageModel.
  */
-export const MessageModelBase = MSTGQLObject
+export const MessageModelBase = ModelBase
   .named('Message')
   .props({
     __typename: types.optional(types.literal("Message"), "Message"),

--- a/examples/3-twitter-clone/src/app/models/ModelBase.ts
+++ b/examples/3-twitter-clone/src/app/models/ModelBase.ts
@@ -1,0 +1,3 @@
+import { MSTGQLObject } from "mst-gql"
+
+export const ModelBase = MSTGQLObject

--- a/examples/3-twitter-clone/src/app/models/UserModel.base.ts
+++ b/examples/3-twitter-clone/src/app/models/UserModel.base.ts
@@ -3,7 +3,8 @@
 /* tslint:disable */
 
 import { types } from "mobx-state-tree"
-import { MSTGQLObject, QueryBuilder } from "mst-gql"
+import { QueryBuilder } from "mst-gql"
+import { ModelBase } from "./ModelBase"
 import { RootStoreType } from "./index"
 
 
@@ -11,7 +12,7 @@ import { RootStoreType } from "./index"
  * UserBase
  * auto generated base class for the model UserModel.
  */
-export const UserModelBase = MSTGQLObject
+export const UserModelBase = ModelBase
   .named('User')
   .props({
     __typename: types.optional(types.literal("User"), "User"),

--- a/examples/3-twitter-clone/src/server/models/MessageModel.base.ts
+++ b/examples/3-twitter-clone/src/server/models/MessageModel.base.ts
@@ -3,7 +3,8 @@
 /* tslint:disable */
 
 import { types } from "mobx-state-tree"
-import { MSTGQLObject, MSTGQLRef, QueryBuilder } from "mst-gql"
+import { MSTGQLRef, QueryBuilder } from "mst-gql"
+import { ModelBase } from "./ModelBase"
 import { MessageModel } from "./MessageModel"
 import { UserModel } from "./UserModel"
 import { RootStoreType } from "./index"
@@ -13,7 +14,7 @@ import { RootStoreType } from "./index"
  * MessageBase
  * auto generated base class for the model MessageModel.
  */
-export const MessageModelBase = MSTGQLObject
+export const MessageModelBase = ModelBase
   .named('Message')
   .props({
     __typename: types.optional(types.literal("Message"), "Message"),

--- a/examples/3-twitter-clone/src/server/models/ModelBase.ts
+++ b/examples/3-twitter-clone/src/server/models/ModelBase.ts
@@ -1,0 +1,3 @@
+import { MSTGQLObject } from "mst-gql"
+
+export const ModelBase = MSTGQLObject

--- a/examples/3-twitter-clone/src/server/models/UserModel.base.ts
+++ b/examples/3-twitter-clone/src/server/models/UserModel.base.ts
@@ -3,7 +3,8 @@
 /* tslint:disable */
 
 import { types } from "mobx-state-tree"
-import { MSTGQLObject, QueryBuilder } from "mst-gql"
+import { QueryBuilder } from "mst-gql"
+import { ModelBase } from "./ModelBase"
 import { RootStoreType } from "./index"
 
 
@@ -11,7 +12,7 @@ import { RootStoreType } from "./index"
  * UserBase
  * auto generated base class for the model UserModel.
  */
-export const UserModelBase = MSTGQLObject
+export const UserModelBase = ModelBase
   .named('User')
   .props({
     __typename: types.optional(types.literal("User"), "User"),

--- a/examples/4-apollo-tutorial/client/src/models/LaunchConnectionModel.base.js
+++ b/examples/4-apollo-tutorial/client/src/models/LaunchConnectionModel.base.js
@@ -2,7 +2,8 @@
 /* eslint-disable */
 
 import { types } from "mobx-state-tree"
-import { MSTGQLObject, MSTGQLRef, QueryBuilder } from "mst-gql"
+import { MSTGQLRef, QueryBuilder } from "mst-gql"
+import { ModelBase } from "./ModelBase"
 import { LaunchModel } from "./LaunchModel"
 import { LaunchModelSelector } from "./LaunchModel.base"
 
@@ -13,7 +14,7 @@ import { LaunchModelSelector } from "./LaunchModel.base"
  *
  * Simple wrapper around our list of launches that contains a cursor to the last item in the list. Pass this cursor to the launches query to fetch results after these.
  */
-export const LaunchConnectionModelBase = MSTGQLObject
+export const LaunchConnectionModelBase = ModelBase
   .named('LaunchConnection')
   .props({
     __typename: types.optional(types.literal("LaunchConnection"), "LaunchConnection"),

--- a/examples/4-apollo-tutorial/client/src/models/LaunchModel.base.js
+++ b/examples/4-apollo-tutorial/client/src/models/LaunchModel.base.js
@@ -2,7 +2,8 @@
 /* eslint-disable */
 
 import { types } from "mobx-state-tree"
-import { MSTGQLObject, MSTGQLRef, QueryBuilder } from "mst-gql"
+import { MSTGQLRef, QueryBuilder } from "mst-gql"
+import { ModelBase } from "./ModelBase"
 import { MissionModel } from "./MissionModel"
 import { MissionModelSelector } from "./MissionModel.base"
 import { RocketModel } from "./RocketModel"
@@ -13,7 +14,7 @@ import { RocketModelSelector } from "./RocketModel.base"
  * LaunchBase
  * auto generated base class for the model LaunchModel.
  */
-export const LaunchModelBase = MSTGQLObject
+export const LaunchModelBase = ModelBase
   .named('Launch')
   .props({
     __typename: types.optional(types.literal("Launch"), "Launch"),

--- a/examples/4-apollo-tutorial/client/src/models/MissionModel.base.js
+++ b/examples/4-apollo-tutorial/client/src/models/MissionModel.base.js
@@ -2,14 +2,15 @@
 /* eslint-disable */
 
 import { types } from "mobx-state-tree"
-import { MSTGQLObject, QueryBuilder } from "mst-gql"
+import { QueryBuilder } from "mst-gql"
+import { ModelBase } from "./ModelBase"
 
 
 /**
  * MissionBase
  * auto generated base class for the model MissionModel.
  */
-export const MissionModelBase = MSTGQLObject
+export const MissionModelBase = ModelBase
   .named('Mission')
   .props({
     __typename: types.optional(types.literal("Mission"), "Mission"),

--- a/examples/4-apollo-tutorial/client/src/models/ModelBase.js
+++ b/examples/4-apollo-tutorial/client/src/models/ModelBase.js
@@ -1,0 +1,3 @@
+import { MSTGQLObject } from "mst-gql"
+
+export const ModelBase = MSTGQLObject

--- a/examples/4-apollo-tutorial/client/src/models/RocketModel.base.js
+++ b/examples/4-apollo-tutorial/client/src/models/RocketModel.base.js
@@ -2,14 +2,15 @@
 /* eslint-disable */
 
 import { types } from "mobx-state-tree"
-import { MSTGQLObject, QueryBuilder } from "mst-gql"
+import { QueryBuilder } from "mst-gql"
+import { ModelBase } from "./ModelBase"
 
 
 /**
  * RocketBase
  * auto generated base class for the model RocketModel.
  */
-export const RocketModelBase = MSTGQLObject
+export const RocketModelBase = ModelBase
   .named('Rocket')
   .props({
     __typename: types.optional(types.literal("Rocket"), "Rocket"),

--- a/examples/4-apollo-tutorial/client/src/models/UserModel.base.js
+++ b/examples/4-apollo-tutorial/client/src/models/UserModel.base.js
@@ -2,7 +2,8 @@
 /* eslint-disable */
 
 import { types } from "mobx-state-tree"
-import { MSTGQLObject, MSTGQLRef, QueryBuilder } from "mst-gql"
+import { MSTGQLRef, QueryBuilder } from "mst-gql"
+import { ModelBase } from "./ModelBase"
 import { LaunchModel } from "./LaunchModel"
 import { LaunchModelSelector } from "./LaunchModel.base"
 
@@ -11,7 +12,7 @@ import { LaunchModelSelector } from "./LaunchModel.base"
  * UserBase
  * auto generated base class for the model UserModel.
  */
-export const UserModelBase = MSTGQLObject
+export const UserModelBase = ModelBase
   .named('User')
   .props({
     __typename: types.optional(types.literal("User"), "User"),


### PR DESCRIPTION
Follow-up to #106

> I guess we can leave the remaining examples as they are, since the migration to having a ModelBase module is seamless. So only the 5-nextjs example integrates this change so far.
>    @zenflow  https://github.com/mobxjs/mst-gql/pull/106#issuecomment-535232807

Actually it's a bit of an annoyance to scaffold an example and see changes, unrelated to what I'm doing, due to the generated files not being updated yet. Also not nice to need to commit these changes in an unrelated branch.

So I went ahead and updated all the examples

/cc @chrisdrackett 