### PR TITLE
Local storage control

### DIFF
--- a/examples/4-apollo-tutorial/client/src/models/RootStore.js
+++ b/examples/4-apollo-tutorial/client/src/models/RootStore.js
@@ -61,6 +61,7 @@ export const RootStore = RootStoreBase.props({
   loginStatus: loginStatus,
   cartItems: types.array(types.string)
 })
+  .extend(localStorageMixin())
   .views(self => ({
     get me() {
       return Array.from(self.users.values())[0]
@@ -107,12 +108,14 @@ export const RootStore = RootStoreBase.props({
         )
         localStorage.setItem("token", data.login)
         self.loginStatus = "loggedIn"
+        self.startStorage()
       } catch {
         self.loginStatus = "error"
       }
     }),
     logout() {
       self.loginStatus = "loggedOut"
+      self.stopStorage()
       localStorage.clear()
     },
     fetchLaunches(after) {
@@ -129,4 +132,3 @@ export const RootStore = RootStoreBase.props({
       )
     }
   }))
-  .extend(localStorageMixin())

--- a/src/localStorageMixin.ts
+++ b/src/localStorageMixin.ts
@@ -19,6 +19,7 @@ export function localStorageMixin(options: LocalStorageMixinOptions = {}) {
   const storage = options.storage || window.localStorage
   const throttleInterval = options.throttle || 5000
   const storageKey = options.storageKey || "mst-gql-rootstore"
+  let __canSave = true
   return (self: StoreType) => ({
     actions: {
       async afterCreate() {
@@ -39,10 +40,16 @@ export function localStorageMixin(options: LocalStorageMixinOptions = {}) {
           onSnapshot(
             self,
             throttle((data: any) => {
-              storage.setItem(storageKey, JSON.stringify(data))
+              if (__canSave) storage.setItem(storageKey, JSON.stringify(data))
             }, throttleInterval)
           )
         )
+      },
+      stopStorage() {
+        __canSave = false
+      },
+      startStorage() {
+        __canSave = true
       }
     }
   })


### PR DESCRIPTION
This PR aims to solve this issue: https://github.com/mobxjs/mst-gql/issues/141

It is possible for the local storage of an app to be saved after the user logs out which can cause problems. I have added two actions to the `localStorageMixin` which can control when snapshots can be saved to localStorage.

In this example, I add something to the cart and logout before the throttle timeout. Then, after the app is logged out, the local storage is set again. This allows me to refresh the page without logging in and still has all of my local storage data.

![Local Storage After Logout](https://user-images.githubusercontent.com/5407471/74557790-cbc7d500-4f15-11ea-84ec-1010a0222b01.gif)

This is a simple PR but I am not sure if there is a more reactive way to do this.