### PR TITLE
#108 handle naming conflict

### DIFF
--- a/generator/generate.js
+++ b/generator/generate.js
@@ -95,15 +95,15 @@ export const ModelBase = MSTGQLObject
       )
     }
 
-    rootTypes.forEach(typeName => {
-      if (!objectTypes.includes(typeName)) {
-        if (isTypeReservedName(typeName)) {
+    rootTypes.forEach(type => {
+      if (!origObjectTypes.includes(type)) {
+        if (isTypeReservedName(type)) {
           throw new Error(
-            `Cannot generate ${typeName}Model, ${typeName} is a graphql reserved name`
+            `Cannot generate ${type}Model, ${type} is a graphql reserved name`
           )
         }
         throw new Error(
-          `The root type specified: '${typeName}' is unknown, excluded or not an OBJECT type!`
+          `The root type specified: '${type}' is unknown, excluded or not an OBJECT type!`
         )
       }
     })

--- a/tests/generator/generate.test.js
+++ b/tests/generator/generate.test.js
@@ -310,3 +310,23 @@ type Query {
     )
   ).toBeTruthy()
 })
+
+test("handle reserved graphql name", () => {
+  try {
+    const schema = `
+        type Subscription {
+          id: ID
+          channel: String
+        }
+        
+        type Query {
+          subscription: Subscription
+        }
+      `
+    scaffold(schema, { roots: ["Subscription"] })
+  } catch (error) {
+    expect(error.message).toMatch(
+      "Cannot generate SubscriptionModel, Subscription is a graphql reserved name"
+    )
+  }
+})


### PR DESCRIPTION
This PR aims to solve this issue: #108.

It return an error when the user try to scaffold a model with a name reserved for graphql such as `Query, Subscription, Mutation, etc`.

Now when you try to use a graphql reserved name you will see a specific error. Ex: `"Cannot generate SubscriptionModel, Subscription is a graphql reserved name"`

To try it just see the test `handle reserved graphql name` in `generate.test.js`.