### PR TITLE
Revert "Fix enum file generation and imports"

### DIFF
--- a/generator/generate.js
+++ b/generator/generate.js
@@ -165,7 +165,7 @@ export const ModelBase = MSTGQLObject
   function handleEnumType(type) {
     const name = type.name
     const enumPostfix = !name.toLowerCase().endsWith("enum") ? "Enum" : ""
-    toExport.push(name + enumPostfix + "Model")
+    toExport.push(name + enumPostfix)
 
     const tsType =
       format === "ts"
@@ -193,7 +193,7 @@ export const ${name}${enumPostfix}Model = ${handleEnumTypeCore(type)}
     if (format === "ts") {
       enumTypes.push(type.name)
     }
-    generateFile(name + enumPostfix + "Model", contents, true)
+    generateFile(name + enumPostfix, contents, true)
   }
 
   function handleEnumTypeCore(type) {
@@ -415,8 +415,7 @@ ${generateFragments(name, primitiveFields, nonPrimitiveFields)}
           primitiveFields.push(fieldName)
           const enumType =
             fieldType.name +
-            (!fieldType.name.toLowerCase().endsWith("enum") ? "Enum" : "") +
-            "Model"
+            (!fieldType.name.toLowerCase().endsWith("enum") ? "Enum" : "")
           if (type.kind !== "UNION" && type.kind !== "INTERFACE") {
             // TODO: import again when enums in query builders are supported
             addImport(enumType, enumType)
@@ -600,9 +599,9 @@ ${objectTypes
 ${enumTypes
   .map(
     t =>
-      `\nimport { ${t} } from "./${t}${(!t.toLowerCase().endsWith("enum")
-        ? "Enum"
-        : "") + "Model"}${importPostFix}"`
+      `\nimport { ${t} } from "./${t}${
+        !t.toLowerCase().endsWith("enum") ? "Enum" : ""
+      }${importPostFix}"`
   )
   .join("")}
 ${ifTS(

--- a/tests/generator/__snapshots__/generate.test.js.snap
+++ b/tests/generator/__snapshots__/generate.test.js.snap
@@ -498,9 +498,9 @@ export const ModelBase = MSTGQLObject
 import { types } from \\"mobx-state-tree\\"
 import { QueryBuilder } from \\"mst-gql\\"
 import { ModelBase } from \\"./ModelBase\\"
-import { RoleEnumModel } from \\"./RoleEnumModel\\"
+import { RoleEnum } from \\"./RoleEnum\\"
 import { RootStoreType } from \\"./index\\"
-import { interest_enumModel } from \\"./interest_enumModel\\"
+import { interest_enum } from \\"./interest_enum\\"
 
 
 /**
@@ -514,8 +514,8 @@ export const UserModelBase = ModelBase
     id: types.identifier,
     name: types.union(types.undefined, types.string),
     avatar: types.union(types.undefined, types.string),
-    role: types.union(types.undefined, RoleEnumModel),
-    interest: types.union(types.undefined, interest_enumModel),
+    role: types.union(types.undefined, RoleEnum),
+    interest: types.union(types.undefined, interest_enum),
   })
   .views(self => ({
     get store() {
@@ -563,7 +563,7 @@ export const UserModel = UserModelBase
     false,
   ],
   Array [
-    "RoleEnumModel",
+    "RoleEnum",
     "/* This is a mst-gql generated file, don't modify it manually */
 /* eslint-disable */
 /* tslint:disable */
@@ -591,7 +591,7 @@ export const RoleEnumModel = types.enumeration(\\"Role\\", [
     true,
   ],
   Array [
-    "interest_enumModel",
+    "interest_enum",
     "/* This is a mst-gql generated file, don't modify it manually */
 /* eslint-disable */
 /* tslint:disable */
@@ -647,8 +647,8 @@ import { MSTGQLStore, configureStoreMixin, QueryOptions, withTypedRefs } from \\
 import { UserModel, UserModelType } from \\"./UserModel\\"
 import { userModelPrimitives, UserModelSelector } from \\"./UserModel.base\\"
 
-import { Role } from \\"./RoleEnumModel\\"
-import { interest_enum } from \\"./interest_enumModel\\"
+import { Role } from \\"./RoleEnum\\"
+import { interest_enum } from \\"./interest_enum\\"
 
 /* The TypeScript type that explicits the refs to other models in order to prevent a circular refs issue */
 type Refs = {
@@ -697,8 +697,8 @@ export const useQuery = createUseQueryHook(StoreContext, React)
 /* tslint:disable */
 
 export * from \\"./UserModel\\"
-export * from \\"./RoleEnumModel\\"
-export * from \\"./interest_enumModel\\"
+export * from \\"./RoleEnum\\"
+export * from \\"./interest_enum\\"
 export * from \\"./RootStore\\"
 export * from \\"./reactUtils\\"
 ",
@@ -726,8 +726,8 @@ export const ModelBase = MSTGQLObject
 import { types } from \\"mobx-state-tree\\"
 import { QueryBuilder } from \\"mst-gql\\"
 import { ModelBase } from \\"./ModelBase\\"
-import { InterestEnumModel } from \\"./InterestEnumModel\\"
-import { RoleEnumModel } from \\"./RoleEnumModel\\"
+import { InterestEnum } from \\"./InterestEnum\\"
+import { RoleEnum } from \\"./RoleEnum\\"
 import { RootStoreType } from \\"./index\\"
 
 
@@ -742,8 +742,8 @@ export const UserModelBase = ModelBase
     id: types.identifier,
     name: types.union(types.undefined, types.string),
     avatar: types.union(types.undefined, types.string),
-    role: types.union(types.undefined, RoleEnumModel),
-    interest: types.union(types.undefined, InterestEnumModel),
+    role: types.union(types.undefined, RoleEnum),
+    interest: types.union(types.undefined, InterestEnum),
   })
   .views(self => ({
     get store() {
@@ -791,7 +791,7 @@ export const UserModel = UserModelBase
     false,
   ],
   Array [
-    "RoleEnumModel",
+    "RoleEnum",
     "/* This is a mst-gql generated file, don't modify it manually */
 /* eslint-disable */
 /* tslint:disable */
@@ -819,7 +819,7 @@ export const RoleEnumModel = types.enumeration(\\"Role\\", [
     true,
   ],
   Array [
-    "InterestEnumModel",
+    "InterestEnum",
     "/* This is a mst-gql generated file, don't modify it manually */
 /* eslint-disable */
 /* tslint:disable */
@@ -875,8 +875,8 @@ import { MSTGQLStore, configureStoreMixin, QueryOptions, withTypedRefs } from \\
 import { UserModel, UserModelType } from \\"./UserModel\\"
 import { userModelPrimitives, UserModelSelector } from \\"./UserModel.base\\"
 
-import { Role } from \\"./RoleEnumModel\\"
-import { InterestEnum } from \\"./InterestEnumModel\\"
+import { Role } from \\"./RoleEnum\\"
+import { InterestEnum } from \\"./InterestEnum\\"
 
 /* The TypeScript type that explicits the refs to other models in order to prevent a circular refs issue */
 type Refs = {
@@ -925,8 +925,8 @@ export const useQuery = createUseQueryHook(StoreContext, React)
 /* tslint:disable */
 
 export * from \\"./UserModel\\"
-export * from \\"./RoleEnumModel\\"
-export * from \\"./InterestEnumModel\\"
+export * from \\"./RoleEnum\\"
+export * from \\"./InterestEnum\\"
 export * from \\"./RootStore\\"
 export * from \\"./reactUtils\\"
 ",

--- a/tests/generator/generate.test.js
+++ b/tests/generator/generate.test.js
@@ -260,7 +260,7 @@ type Query {
 
   expect(findFile(output, "UserModel")).toBeTruthy()
 
-  const roleEnumFile = findFile(output, "RoleEnumModel")
+  const roleEnumFile = findFile(output, "RoleEnum")
   expect(roleEnumFile).toBeTruthy()
 
   // TS type is plain Role
@@ -273,7 +273,7 @@ type Query {
     )
   ).toBeTruthy()
 
-  const interestEnumFile = findFile(output, "interest_enumModel")
+  const interestEnumFile = findFile(output, "interest_enum")
   expect(interestEnumFile).toBeTruthy()
   // TS type is plain interest_enum
   expect(
@@ -323,7 +323,7 @@ type Query {
 
   expect(findFile(output, "UserModel")).toBeTruthy()
 
-  const roleEnumFile = findFile(output, "RoleEnumModel")
+  const roleEnumFile = findFile(output, "RoleEnum")
   expect(roleEnumFile).toBeTruthy()
   expect(hasFileContentExact(roleEnumFile, "export enum Role {")).toBeTruthy()
   expect(
@@ -333,7 +333,7 @@ type Query {
     )
   ).toBeTruthy()
 
-  const interestEnumFile = findFile(output, "InterestEnumModel")
+  const interestEnumFile = findFile(output, "InterestEnum")
   console.log("interestEnumFile", interestEnumFile)
   expect(interestEnumFile).toBeTruthy()
   expect(


### PR DESCRIPTION
I missed this during the review, but these are not actually models so I'm reverting this commit.