### PR TITLE
Feature/apollo header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,7 +633,7 @@ For examples, see the sections [Loading and rendering your first data](#loading-
 
 ## `localStorageMixin`
 
-The `localStorageMixin` can be used to automatically safe the full state of the `RootStore`. By default the store is saved after every change, but throttle to be saved once per 5 seconds. (The reason for the trotthling is that, although snapshotting is cheap, serializing a a snapshot to a string is expensive).
+The `localStorageMixin` can be used to automatically save the full state of the `RootStore`. By default the store is saved after every change, but throttle to be saved once per 5 seconds. (The reason for the throttling is that, although snapshotting is cheap, serializing a a snapshot to a string is expensive).
 
 Options:
 

--- a/generator/config.js
+++ b/generator/config.js
@@ -20,10 +20,10 @@ exports.defaultConfig = {
 exports.getConfig = function getConfig() {
   try {
     const result = explorer.search()
-    return result ? result.config : defaultConfig
+    return result ? result.config : exports.defaultConfig
   } catch (e) {
     console.error(e.message)
-    return defaultConfig
+    return exports.defaultConfig
   }
 }
 

--- a/generator/config.js
+++ b/generator/config.js
@@ -13,7 +13,7 @@ const defaultConfig = {
   outDir: "src/models",
   roots: [],
   noReact: false,
-  namingConvention: "js" // supported option: "js", "asis"
+  namingConvention: "js" // supported option: "js", "asis",
 }
 
 exports.getConfig = function getConfig() {
@@ -42,6 +42,11 @@ exports.mergeConfigs = function mergeConfigs(args, config) {
     noReact: !!args["--noReact"] || config.noReact,
     namingConvention: args["--dontRenameModels"]
       ? "asis"
-      : config.namingConvention
+      : config.namingConvention,
+    header:
+      args["--header"] ||
+      Object.keys(config.header)
+        .map(key => `${key}:${config.header[key]}`)
+        .join(" --header=") // if multiple headers are passed in config, chain them up to pass on to apollo cli
   }
 }

--- a/generator/config.js
+++ b/generator/config.js
@@ -4,7 +4,7 @@ const { cosmiconfigSync } = require("cosmiconfig")
 
 const explorer = cosmiconfigSync("mst-gql")
 
-const defaultConfig = {
+exports.defaultConfig = {
   excludes: [],
   force: false,
   format: "js",
@@ -13,7 +13,8 @@ const defaultConfig = {
   outDir: "src/models",
   roots: [],
   noReact: false,
-  namingConvention: "js" // supported option: "js", "asis",
+  namingConvention: "js", // supported option: "js", "asis",
+  header: undefined
 }
 
 exports.getConfig = function getConfig() {
@@ -27,6 +28,13 @@ exports.getConfig = function getConfig() {
 }
 
 exports.mergeConfigs = function mergeConfigs(args, config) {
+  const headerConfigValues =
+    config && config.header
+      ? Object.keys(config.header)
+          .map(key => `${key}:${config.header[key]}`)
+          .join(" --header=")
+      : undefined
+
   return {
     format: args["--format"] || config.format,
     outDir: resolve(process.cwd(), args["--outDir"] || config.outDir),
@@ -43,10 +51,6 @@ exports.mergeConfigs = function mergeConfigs(args, config) {
     namingConvention: args["--dontRenameModels"]
       ? "asis"
       : config.namingConvention,
-    header:
-      args["--header"] ||
-      Object.keys(config.header)
-        .map(key => `${key}:${config.header[key]}`)
-        .join(" --header=") // if multiple headers are passed in config, chain them up to pass on to apollo cli
+    header: args["--header"] || headerConfigValues // if multiple headers are passed in config, chain them up to pass on to apollo cli
   }
 }

--- a/generator/mst-gql-scaffold.js
+++ b/generator/mst-gql-scaffold.js
@@ -17,7 +17,8 @@ const definition = {
   "--force": Boolean,
   "--noReact": Boolean,
   "--separate": Boolean,
-  "--dontRenameModels": Boolean
+  "--dontRenameModels": Boolean,
+  "--header": String
 }
 
 function main() {
@@ -43,7 +44,8 @@ function main() {
     modelsOnly,
     forceAll,
     noReact,
-    namingConvention
+    namingConvention,
+    header
   } = mergeConfigs(args, config)
   const separate = !!args["--separate"]
 
@@ -67,9 +69,10 @@ function main() {
   let json
   if (input.startsWith("http:") || input.startsWith("https:")) {
     const tmpFile = "tmp_schema.json"
-    child_process.execSync(
-      `${__dirname}/../node_modules/.bin/apollo schema:download --endpoint=${input} ${tmpFile}`
-    )
+    const command = `${__dirname}/../node_modules/.bin/apollo client:download-schema --endpoint=${input} ${tmpFile} ${
+      header ? `--header=${header}` : "" // the header options MUST be after the output 0_o
+    }`
+    child_process.execSync(command)
     json = JSON.parse(fs.readFileSync(tmpFile, "utf8"))
     fs.unlinkSync(tmpFile)
   } else if (input.endsWith(".json")) {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     }
   },
   "dependencies": {
-    "apollo": "^2.25.0",
+    "apollo": "^2.27.0",
     "arg": "^4.1.1",
     "camelcase": "^5.3.1",
     "cosmiconfig": "^6.0.0",

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -1,0 +1,66 @@
+/// <reference types="jest"/>
+
+const { mergeConfigs, defaultConfig } = require("../generator/config")
+
+const testArgsWithoutHeader = {
+  _: ["file_input"],
+  "--format": undefined,
+  "--outDir": undefined,
+  "--roots": undefined,
+  "--excludes": undefined,
+  "--modelsOnly": undefined,
+  "--force": undefined,
+  "--noReact": undefined,
+  "--separate": undefined,
+  "--dontRenameModels": undefined,
+  "--header": undefined
+}
+
+const testArgsWithHeader = {
+  ...testArgsWithoutHeader,
+  "--header": "X-Hasura-Admin-Secret:supersecret"
+}
+
+const configWithHeader = {
+  input: "http://localhost:8080/v1/graphql",
+  format: "ts",
+  outDir: "src/models",
+  roots: ["todos", "otherthings"],
+  header: {
+    "x-hasura-admin-secret": "supersecret"
+  }
+}
+
+const testConfigMultipleHeaders = {
+  ...configWithHeader,
+  header: {
+    "x-hasura-admin-secret": "supersecret",
+    "x-hasura-role": "superuser"
+  }
+}
+
+test("header is used when passed as argument", () => {
+  const results = mergeConfigs(testArgsWithHeader, defaultConfig)
+
+  expect(results.header).toBe(testArgsWithHeader["--header"])
+})
+
+test("header is used when passed as argument even if config is passed", () => {
+  const results = mergeConfigs(testArgsWithHeader, configWithHeader)
+
+  expect(results.header).toBe(testArgsWithHeader["--header"])
+})
+
+test("config is used for header", () => {
+  const results = mergeConfigs(testArgsWithoutHeader, configWithHeader)
+
+  expect(results.header).toBe("x-hasura-admin-secret:supersecret")
+})
+
+test("config is used for multiple headers", () => {
+  const results = mergeConfigs(testArgsWithoutHeader, testConfigMultipleHeaders)
+
+  expect(results.header).toBe(
+    "x-hasura-admin-secret:supersecret --header=x-hasura-role:superuser"
+  )
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@apollo/federation@0.13.2":
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/@apollo/federation/-/federation-0.13.2.tgz#a9f842abd1619fe5cd732c56cfbc45dab0ae784a"
-  integrity sha512-62uXIIHxHXG71gSwROFt8yxtYeUZ2BaIgAkxZ1H82GB4+s1gt4xwizcmmCWqQhK3KBy4LbPOfI1YyHW4Wv5ZpQ==
+"@apollo/federation@0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@apollo/federation/-/federation-0.14.0.tgz#c1fa14610fc1d7193688cfed3f2989a27f77c7cd"
+  integrity sha512-JNIWj8p9vd4c1kZFl70B1wUt2RwttSUHVef4UfTAyhN7PHX5D4J+IHTYurgOIC/yUqIURi7iVh8vAtudhpxtEA==
   dependencies:
     apollo-graphql "^0.4.0"
     apollo-server-env "^2.4.3"
@@ -85,10 +85,10 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@7.9.0":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.9.0.tgz#0f67adea4ec39dad6e63345f70eec33014d78c89"
-  integrity sha512-onl4Oy46oGCzymOXtKMQpI7VXtCbTSHK1kqBydZ6AmzuNcacEVqGk9tZtAS+48IA9IstZcDCgIg8hQKnb7suRw==
+"@babel/generator@7.9.4":
+  version "7.9.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.9.4.tgz#12441e90c3b3c4159cdecf312075bf1a8ce2dbce"
+  integrity sha512-rjP8ahaDy/ouhrvCoU1E5mqaitWrxwuNGU+dy1EpaoK48jZay4MdkskKGIMHLZNewg8sAsqpGSREJwP0zH3YQA==
   dependencies:
     "@babel/types" "^7.9.0"
     jsesc "^2.5.1"
@@ -1607,60 +1607,60 @@ anymatch@^3.0.3:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-apollo-codegen-core@^0.36.5:
-  version "0.36.5"
-  resolved "https://registry.yarnpkg.com/apollo-codegen-core/-/apollo-codegen-core-0.36.5.tgz#9941058b39e61e54757c3aa9783c143670f4a3f5"
-  integrity sha512-ickLdaD+H9kaRHzQDAG5i+QMfmUfFc+MUn+e5lGlXPnL/h9WOX2M22z2mXKd4Q3ErH9SQe2SPB8Fpk85WnnAhA==
+apollo-codegen-core@^0.36.6:
+  version "0.36.6"
+  resolved "https://registry.yarnpkg.com/apollo-codegen-core/-/apollo-codegen-core-0.36.6.tgz#44b46cab3037e76de81a06970ccc326f66f9d05b"
+  integrity sha512-wVQkjYrbJa3Ut98pP9z/DnPPdtYaXLmOe83TOM1/krX3MlhTD17VWx1pkLht+1Tuy7hEZErxA5d2bwaynSNfCg==
   dependencies:
-    "@babel/generator" "7.9.0"
+    "@babel/generator" "7.9.4"
     "@babel/parser" "^7.1.3"
     "@babel/types" "7.9.0"
     apollo-env "^0.6.2"
-    apollo-language-server "^1.21.0"
+    apollo-language-server "^1.21.1"
     ast-types "^0.13.0"
     common-tags "^1.5.1"
     recast "^0.18.0"
 
-apollo-codegen-flow@^0.34.5:
-  version "0.34.5"
-  resolved "https://registry.yarnpkg.com/apollo-codegen-flow/-/apollo-codegen-flow-0.34.5.tgz#c523bc5ab443dd57f179f04473c1ce7422a5f7fd"
-  integrity sha512-GHcokyHu2fPdXS8DGsYcPjj24Vbwfdw73VULzTazdbHTJ6loSVlFeRtU5B7rQDxFTyd4VL4muVfRXarV0tib3Q==
+apollo-codegen-flow@^0.34.6:
+  version "0.34.6"
+  resolved "https://registry.yarnpkg.com/apollo-codegen-flow/-/apollo-codegen-flow-0.34.6.tgz#210388330fba94c5a0a496657fab82baebe15a3b"
+  integrity sha512-jgoa9dlWNec+qD02hsWaLYtd2p9A97IbEcWX7aLaE5fifrK1rIA7lY6TLwlXc663YxBcgZzGaCfKtatqndfg9A==
   dependencies:
-    "@babel/generator" "7.9.0"
+    "@babel/generator" "7.9.4"
     "@babel/types" "7.9.0"
-    apollo-codegen-core "^0.36.5"
+    apollo-codegen-core "^0.36.6"
     change-case "^3.0.1"
     common-tags "^1.5.1"
     inflected "^2.0.3"
 
-apollo-codegen-scala@^0.35.5:
-  version "0.35.5"
-  resolved "https://registry.yarnpkg.com/apollo-codegen-scala/-/apollo-codegen-scala-0.35.5.tgz#b227402d861567fbac22f3a78a5405e5b2218bd7"
-  integrity sha512-zzLVvV82zkxWSAP+5JiKQMEhFDort+0ix56W5hA9MmiTX4mvz/lW1wM5XXOxKUL46tMBKKo0WNGUcLBijDB0Hw==
+apollo-codegen-scala@^0.35.6:
+  version "0.35.6"
+  resolved "https://registry.yarnpkg.com/apollo-codegen-scala/-/apollo-codegen-scala-0.35.6.tgz#ffea9edd9b9263846e95d27a8c35b82ab3e7f998"
+  integrity sha512-H5NAMdCb5cMB/YGUqCSDspPLRxMFklc9m2CBVpdo90cjIjb8YEJDJfqpLt1D6X5fX2xPhNYptCyeDkY1qXC9XQ==
   dependencies:
-    apollo-codegen-core "^0.36.5"
+    apollo-codegen-core "^0.36.6"
     change-case "^3.0.1"
     common-tags "^1.5.1"
     inflected "^2.0.3"
 
-apollo-codegen-swift@^0.36.5:
-  version "0.36.5"
-  resolved "https://registry.yarnpkg.com/apollo-codegen-swift/-/apollo-codegen-swift-0.36.5.tgz#b7b2cda0100d659bb380093cd67c3ce022959cb6"
-  integrity sha512-HAQByrPQ1QLhfihliUVNTeKOC6g0RwXBKubM3KPlKEX7E9evIB9PrQpQc8RKyiqu/7sJrM2YDHUk6ADqwBQsfg==
+apollo-codegen-swift@^0.36.6:
+  version "0.36.6"
+  resolved "https://registry.yarnpkg.com/apollo-codegen-swift/-/apollo-codegen-swift-0.36.6.tgz#39b9625cb774bd6ac4037e2390976837f39608f3"
+  integrity sha512-/F96GbAjBcLE8pKFv8+k4FyAaegPHl0vxF/2abxQEBfolwyLk5JufEBC2fSkS9Gf8PLQlDcEIxUFyqmBQzMbpA==
   dependencies:
-    apollo-codegen-core "^0.36.5"
+    apollo-codegen-core "^0.36.6"
     change-case "^3.0.1"
     common-tags "^1.5.1"
     inflected "^2.0.3"
 
-apollo-codegen-typescript@^0.36.5:
-  version "0.36.5"
-  resolved "https://registry.yarnpkg.com/apollo-codegen-typescript/-/apollo-codegen-typescript-0.36.5.tgz#8beb5555f55e1d8ab31acde5bfbb90371fdff7e3"
-  integrity sha512-OXPZ87Y8yCWqiuw00a7NxbLUcuI/9NVvZi/Y1Pbp9rhuDHAv9uL1QsF/84fnzJCOOQFdG2/kjA3f6tzONAtHog==
+apollo-codegen-typescript@^0.36.6:
+  version "0.36.6"
+  resolved "https://registry.yarnpkg.com/apollo-codegen-typescript/-/apollo-codegen-typescript-0.36.6.tgz#f844c25d62fb243347d8a05d66f14b76cb46e445"
+  integrity sha512-Y6UZ+HP+RDp0zk3h+rCJ/7eHQKUea3fPB6YplZ80dAzcwYYfsx0WprtdSYnUgPT8Rimeg+WDZ4jzQpZ/udPiGQ==
   dependencies:
-    "@babel/generator" "7.9.0"
+    "@babel/generator" "7.9.4"
     "@babel/types" "7.9.0"
-    apollo-codegen-core "^0.36.5"
+    apollo-codegen-core "^0.36.6"
     change-case "^3.0.1"
     common-tags "^1.5.1"
     inflected "^2.0.3"
@@ -1691,12 +1691,12 @@ apollo-graphql@^0.4.0, apollo-graphql@^0.4.1:
     apollo-env "^0.6.2"
     lodash.sortby "^4.7.0"
 
-apollo-language-server@^1.21.0:
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/apollo-language-server/-/apollo-language-server-1.21.0.tgz#01ce45b90c67a7f7f0acc3d163253f01ec1d8114"
-  integrity sha512-MWTHX1ckIbbq7h3lL+2Axs7NPJrkKwvHNGpx0XdcQIW93NeZWaD8XlmXzAUNOb2EmEmSP/FI1kkRjDmQb1ehXA==
+apollo-language-server@^1.21.1:
+  version "1.21.1"
+  resolved "https://registry.yarnpkg.com/apollo-language-server/-/apollo-language-server-1.21.1.tgz#c89df8bd0691f3f2131a0d8c54ad2e715ff79060"
+  integrity sha512-Yu5nw+0lGWNY9PmgogzXVRvnCNluGImeNmg4jQkXQlBR2TsQ9P3YSwujDIJ5cWWKjyi/0+3PtRYvIna58xZ/fg==
   dependencies:
-    "@apollo/federation" "0.13.2"
+    "@apollo/federation" "0.14.0"
     "@apollographql/apollo-tools" "^0.4.5"
     "@apollographql/graphql-language-service-interface" "^2.0.2"
     "@endemolshinegroup/cosmiconfig-typescript-loader" "^1.0.0"
@@ -1797,10 +1797,10 @@ apollo-utilities@^1.3.0:
     ts-invariant "^0.4.0"
     tslib "^1.10.0"
 
-apollo@^2.25.0:
-  version "2.26.0"
-  resolved "https://registry.yarnpkg.com/apollo/-/apollo-2.26.0.tgz#f8274f22517ce9e3cfe5c4d0ce9826e200755cca"
-  integrity sha512-izis5eXpzEwboj6nP/4ifkne24ayQ5ioBpO3rAmz89+XIaFqAiejrD2rFen+w/1n6nL1oUoTAwJWZRhSkguOhg==
+apollo@^2.27.0:
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/apollo/-/apollo-2.27.0.tgz#2fa56f34ab239de5a1047cb17e42019f42b36c0b"
+  integrity sha512-yA4/DihmCuz+8k1zsHCtuEslVtAY1oc9mCv7YLUr2B7TVLgbEzNNzNciMbSa5SIczt0S5I+tr6pBhMYPgsLN3A==
   dependencies:
     "@apollographql/apollo-tools" "^0.4.5"
     "@oclif/command" "1.5.19"
@@ -1811,14 +1811,14 @@ apollo@^2.25.0:
     "@oclif/plugin-not-found" "1.2.3"
     "@oclif/plugin-plugins" "1.7.9"
     "@oclif/plugin-warn-if-update-available" "1.7.0"
-    apollo-codegen-core "^0.36.5"
-    apollo-codegen-flow "^0.34.5"
-    apollo-codegen-scala "^0.35.5"
-    apollo-codegen-swift "^0.36.5"
-    apollo-codegen-typescript "^0.36.5"
+    apollo-codegen-core "^0.36.6"
+    apollo-codegen-flow "^0.34.6"
+    apollo-codegen-scala "^0.35.6"
+    apollo-codegen-swift "^0.36.6"
+    apollo-codegen-typescript "^0.36.6"
     apollo-env "^0.6.2"
     apollo-graphql "^0.4.1"
-    apollo-language-server "^1.21.0"
+    apollo-language-server "^1.21.1"
     chalk "2.4.2"
     cli-ux "5.4.5"
     env-ci "3.2.2"
@@ -1831,7 +1831,7 @@ apollo@^2.25.0:
     listr "0.14.3"
     lodash.identity "3.0.0"
     lodash.pickby "4.6.0"
-    mkdirp "^1.0.3"
+    mkdirp "0.5.1"
     moment "2.24.0"
     strip-ansi "5.2.0"
     table "5.4.6"
@@ -5776,6 +5776,11 @@ minimatch@^3.0.2, minimatch@^3.0.4, minimatch@~3.0.2:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimist@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
+
 minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
@@ -5794,17 +5799,19 @@ mkdirp-classic@^0.5.2:
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.2.tgz#54c441ce4c96cd7790e10b41a87aa51068ecab2b"
   integrity sha512-ejdnDQcR75gwknmMw/tx02AuRs8jCtqFoFqDZMjiNxsu85sRIJVXDKHuLYvUUPRBUtV2FpSZa9bL1BUa3BdR2g==
 
+mkdirp@0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
+  dependencies:
+    minimist "0.0.8"
+
 mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
-
-mkdirp@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
-  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 mobx-react-lite@2:
   version "2.0.5"


### PR DESCRIPTION
Fixes #151 

Adds support for `--header` flag to CLI.  Example:

`mst-gql --header=X-Hasura-Admin-Secret:supersecret`

Adds support for a header in a config object.  Example (in config or package.json):

```
"mst-gql": {
    "input": "http://localhost:8080/v1/graphql",
    "format": "ts",
    "outDir": "src/models",
    "roots": [
      "todos",
      "otherthings"
    ],
    "header": {
      "x-hasura-admin-secret": "supersecret",
    }
  }
```

Feedback is welcome.