### PR TITLE
Clear timeout and schedule a new throttle with the correct args

### DIFF
--- a/examples/3-twitter-clone/src/app/models/RootStore.ts
+++ b/examples/3-twitter-clone/src/app/models/RootStore.ts
@@ -4,6 +4,7 @@ import { types } from "mobx-state-tree"
 import { MessageModel } from "./MessageModel"
 import { selectFromMessage } from "./MessageModel.base"
 import { UserModelType } from "./UserModel"
+import { localStorageMixin } from "mst-gql"
 
 export interface RootStoreType extends Instance<typeof RootStore.Type> {}
 
@@ -15,15 +16,18 @@ export const MESSAGE_FRAGMENT = selectFromMessage()
   .likes()
   .toString()
 
-export const RootStore = RootStoreBase.props({
-  // The store itself does store Messages in loading order,
-  // so we use an additional collection of references, to preserve the order as
-  // it should be, regardless whether we are loading new or old messages.
-  sortedMessages: types.optional(
-    types.array(types.reference(MessageModel as any)),
-    []
-  )
-})
+export const RootStore = RootStoreBase.extend(
+  localStorageMixin({ throttle: 1000 })
+)
+  .props({
+    // The store itself does store Messages in loading order,
+    // so we use an additional collection of references, to preserve the order as
+    // it should be, regardless whether we are loading new or old messages.
+    sortedMessages: types.optional(
+      types.array(types.reference(MessageModel as any)),
+      []
+    )
+  })
   .views(self => ({
     get me(): UserModelType {
       return self.users.get("mweststrate")

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "fast-json-stable-stringify": "^2.1.0",
     "graphql": "^14.6.0",
     "graphql-request": "^1.8.2",
-    "pluralize": "^8.0.0"
+    "pluralize": "^8.0.0",
+    "throttle-debounce": "^2.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",
@@ -64,6 +65,7 @@
     "@types/pluralize": "^0.0.29",
     "@types/react": "^16.8.24",
     "@types/react-dom": "^16.8.5",
+    "@types/throttle-debounce": "^2.1.0",
     "escape-string-regexp": "^2.0.0",
     "graphql-tag": "^2.10.1",
     "husky": "^3.0.0",

--- a/src/localStorageMixin.ts
+++ b/src/localStorageMixin.ts
@@ -6,6 +6,8 @@ import {
   onSnapshot
 } from "mobx-state-tree"
 
+import { throttle } from "throttle-debounce"
+
 // TODO: support skipping parts of the store, with a key filter for example
 type LocalStorageMixinOptions = {
   storage?: {
@@ -38,39 +40,12 @@ export function localStorageMixin(options: LocalStorageMixinOptions = {}) {
           self,
           onSnapshot(
             self,
-            throttle((data: any) => {
+            throttle(throttleInterval, (data: any) => {
               storage.setItem(storageKey, JSON.stringify(data))
-            }, throttleInterval)
+            })
           )
         )
       }
     }
   })
-}
-
-function throttle(fn: Function, delay: number) {
-  let lastCall = 0
-  let scheduled = false
-
-  return function(...args: any[]) {
-    // already scheduled
-    if (scheduled) return
-    const now = +new Date()
-    if (now - lastCall < delay) {
-      if (!scheduled) {
-        // within throttle period, but no next tick scheduled, schedule now
-        scheduled = true
-        setTimeout(() => {
-          // run and reset
-          lastCall = +new Date()
-          scheduled = false
-          fn.apply(null, args)
-        }, delay - (now - lastCall) + 10) // fire at the end of the current delay period
-      }
-    } else {
-      // outside throttle period, can execute immediately
-      lastCall = now
-      fn.apply(null, args)
-    }
-  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1450,6 +1450,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
+"@types/throttle-debounce@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/throttle-debounce/-/throttle-debounce-2.1.0.tgz#1c3df624bfc4b62f992d3012b84c56d41eab3776"
+  integrity sha512-5eQEtSCoESnh2FsiLTxE121IiE60hnMqcb435fShf4bpLRjEu1Eoekht23y6zXS9Ts3l+Szu3TARnTsA0GkOkQ==
+
 "@types/yargs-parser@*":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
@@ -8488,6 +8493,11 @@ throat@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
   integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
+
+throttle-debounce@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-2.1.0.tgz#257e648f0a56bd9e54fe0f132c4ab8611df4e1d5"
+  integrity sha512-AOvyNahXQuU7NN+VVvOOX+uW6FPaWdAOdRP5HfwYxAfCzXTFKRMoIMk+n+po318+ktcChx+F1Dd91G3YHeMKyg==
 
 timsort@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
closes: https://github.com/mobxjs/mst-gql/issues/224

This updates the `throttle` function in `localStorageMixin` to save with correct args. The function clears the timeout that was scheduled and re-schedules it with the latest args and the new time.

I mostly took this code from https://github.com/github/mini-throttle.

Here is an example of the two side by side and how they work:
https://codesandbox.io/s/upbeat-williamson-djyqb?file=/src/App.tsx