### PR TITLE
Reset error after successful query

### DIFF
--- a/src/Query.ts
+++ b/src/Query.ts
@@ -125,6 +125,7 @@ export class Query<T = unknown> implements PromiseLike<T> {
     promise.then(
       action((data: any) => {
         this.loading = false
+        this.error = false
         this.data = data
       }),
       action(error => {


### PR DESCRIPTION
Fix error property still containing the previous error after a successful refetch, if the initial query failed.