### PR TITLE
Base action types

### DIFF
--- a/examples/1-getting-started/src/app/models/RootStore.base.ts
+++ b/examples/1-getting-started/src/app/models/RootStore.base.ts
@@ -23,7 +23,6 @@ type Refs = {
 /**
 * Enums for the names of base graphql actions
 */
-
 export enum RootStoreBaseQueries {
 queryTodos="queryTodos"
 }

--- a/examples/1-getting-started/src/app/models/RootStore.base.ts
+++ b/examples/1-getting-started/src/app/models/RootStore.base.ts
@@ -19,6 +19,18 @@ type Refs = {
   todos: ObservableMap<string, TodoModelType>
 }
 
+
+/**
+* Enums for the names of base graphql actions
+*/
+
+export enum RootStoreBaseQueries {
+queryTodos="queryTodos"
+}
+export enum RootStoreBaseMutations {
+mutateTodos="mutateTodos"
+}
+
 /**
 * Store, managing, among others, all the objects received through graphQL
 */

--- a/examples/2-scaffolding/src/models/RootStore.base.ts
+++ b/examples/2-scaffolding/src/models/RootStore.base.ts
@@ -27,7 +27,6 @@ type Refs = {
 /**
 * Enums for the names of base graphql actions
 */
-
 export enum RootStoreBaseQueries {
 queryQuery="queryQuery",
 queryPokemons="queryPokemons",

--- a/examples/2-scaffolding/src/models/RootStore.base.ts
+++ b/examples/2-scaffolding/src/models/RootStore.base.ts
@@ -23,6 +23,22 @@ type Refs = {
   attacks: ObservableMap<string, AttackModelType>
 }
 
+
+/**
+* Enums for the names of base graphql actions
+*/
+
+export enum RootStoreBaseQueries {
+queryQuery="queryQuery",
+queryPokemons="queryPokemons",
+queryPokemon="queryPokemon"
+}
+export enum RootStoreBaseMutations {
+mutateQuery="mutateQuery",
+mutatePokemons="mutatePokemons",
+mutatePokemon="mutatePokemon"
+}
+
 /**
 * Store, managing, among others, all the objects received through graphQL
 */

--- a/examples/3-twitter-clone/src/app/models/RootStore.base.ts
+++ b/examples/3-twitter-clone/src/app/models/RootStore.base.ts
@@ -20,8 +20,16 @@ type Refs = {
 /**
 * Enums for the names of base graphql actions
 */
-export type RootStoreBaseQueries = "queryMessages" | "queryMessage" | "queryMe"
-export type RootStoreBaseMutations = "mutateMessages" | "mutateMessage" | "mutateMe"
+export enum RootStoreBaseQueries {
+queryMessages="queryMessages",
+queryMessage="queryMessage",
+queryMe="queryMe"
+}
+export enum RootStoreBaseMutations {
+mutateMessages="mutateMessages",
+mutateMessage="mutateMessage",
+mutateMe="mutateMe"
+}
 
 /**
 * Store, managing, among others, all the objects received through graphQL

--- a/examples/3-twitter-clone/src/app/models/RootStore.base.ts
+++ b/examples/3-twitter-clone/src/app/models/RootStore.base.ts
@@ -18,6 +18,20 @@ type Refs = {
 }
 
 /**
+* Enums for the names of graphql actions in the root store
+*/
+export enum RootStoreBaseQueries {
+queryMessages="queryMessages",
+queryMessage="queryMessage",
+queryMe="queryMe"
+}
+export enum RootStoreBaseMutations {
+mutationMessages="mutationMessages",
+mutationMessage="mutationMessage",
+mutationMe="mutationMe"
+}
+
+/**
 * Store, managing, among others, all the objects received through graphQL
 */
 export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore

--- a/examples/3-twitter-clone/src/app/models/RootStore.base.ts
+++ b/examples/3-twitter-clone/src/app/models/RootStore.base.ts
@@ -18,7 +18,7 @@ type Refs = {
 }
 
 /**
-* Enums for the names of graphql actions in the root store
+* Enums for the names of base graphql actions
 */
 export enum RootStoreBaseQueries {
 queryMessages="queryMessages",
@@ -26,9 +26,9 @@ queryMessage="queryMessage",
 queryMe="queryMe"
 }
 export enum RootStoreBaseMutations {
-mutationMessages="mutationMessages",
-mutationMessage="mutationMessage",
-mutationMe="mutationMe"
+mutateMessages="mutateMessages",
+mutateMessage="mutateMessage",
+mutateMe="mutateMe"
 }
 
 /**

--- a/examples/3-twitter-clone/src/app/models/RootStore.base.ts
+++ b/examples/3-twitter-clone/src/app/models/RootStore.base.ts
@@ -17,6 +17,7 @@ type Refs = {
   users: ObservableMap<string, UserModelType>
 }
 
+
 /**
 * Enums for the names of base graphql actions
 */

--- a/examples/3-twitter-clone/src/app/models/RootStore.base.ts
+++ b/examples/3-twitter-clone/src/app/models/RootStore.base.ts
@@ -20,16 +20,8 @@ type Refs = {
 /**
 * Enums for the names of base graphql actions
 */
-export enum RootStoreBaseQueries {
-queryMessages="queryMessages",
-queryMessage="queryMessage",
-queryMe="queryMe"
-}
-export enum RootStoreBaseMutations {
-mutateMessages="mutateMessages",
-mutateMessage="mutateMessage",
-mutateMe="mutateMe"
-}
+export type RootStoreBaseQueries = "queryMessages" | "queryMessage" | "queryMe"
+export type RootStoreBaseMutations = "mutateMessages" | "mutateMessage" | "mutateMe"
 
 /**
 * Store, managing, among others, all the objects received through graphQL

--- a/examples/3-twitter-clone/src/server/models/RootStore.base.ts
+++ b/examples/3-twitter-clone/src/server/models/RootStore.base.ts
@@ -16,7 +16,7 @@ type Refs = {
 }
 
 /**
-* Enums for the names of graphql actions in the root store
+* Enums for the names of base graphql actions
 */
 export enum RootStoreBaseQueries {
 queryMessages="queryMessages",
@@ -24,9 +24,9 @@ queryMessage="queryMessage",
 queryMe="queryMe"
 }
 export enum RootStoreBaseMutations {
-mutationMessages="mutationMessages",
-mutationMessage="mutationMessage",
-mutationMe="mutationMe"
+mutateMessages="mutateMessages",
+mutateMessage="mutateMessage",
+mutateMe="mutateMe"
 }
 
 /**

--- a/examples/3-twitter-clone/src/server/models/RootStore.base.ts
+++ b/examples/3-twitter-clone/src/server/models/RootStore.base.ts
@@ -16,6 +16,20 @@ type Refs = {
 }
 
 /**
+* Enums for the names of graphql actions in the root store
+*/
+export enum RootStoreBaseQueries {
+queryMessages="queryMessages",
+queryMessage="queryMessage",
+queryMe="queryMe"
+}
+export enum RootStoreBaseMutations {
+mutationMessages="mutationMessages",
+mutationMessage="mutationMessage",
+mutationMe="mutationMe"
+}
+
+/**
 * Store, managing, among others, all the objects received through graphQL
 */
 export const RootStoreBase = withTypedRefs<Refs>()(types.model()

--- a/examples/3-twitter-clone/src/server/models/RootStore.base.ts
+++ b/examples/3-twitter-clone/src/server/models/RootStore.base.ts
@@ -18,8 +18,16 @@ type Refs = {
 /**
 * Enums for the names of base graphql actions
 */
-export type RootStoreBaseQueries = "queryMessages" | "queryMessage" | "queryMe"
-export type RootStoreBaseMutations = "mutateMessages" | "mutateMessage" | "mutateMe"
+export enum RootStoreBaseQueries {
+queryMessages="queryMessages",
+queryMessage="queryMessage",
+queryMe="queryMe"
+}
+export enum RootStoreBaseMutations {
+mutateMessages="mutateMessages",
+mutateMessage="mutateMessage",
+mutateMe="mutateMe"
+}
 
 /**
 * Store, managing, among others, all the objects received through graphQL

--- a/examples/3-twitter-clone/src/server/models/RootStore.base.ts
+++ b/examples/3-twitter-clone/src/server/models/RootStore.base.ts
@@ -15,6 +15,7 @@ type Refs = {
   users: ObservableMap<string, UserModelType>
 }
 
+
 /**
 * Enums for the names of base graphql actions
 */

--- a/examples/3-twitter-clone/src/server/models/RootStore.base.ts
+++ b/examples/3-twitter-clone/src/server/models/RootStore.base.ts
@@ -18,16 +18,8 @@ type Refs = {
 /**
 * Enums for the names of base graphql actions
 */
-export enum RootStoreBaseQueries {
-queryMessages="queryMessages",
-queryMessage="queryMessage",
-queryMe="queryMe"
-}
-export enum RootStoreBaseMutations {
-mutateMessages="mutateMessages",
-mutateMessage="mutateMessage",
-mutateMe="mutateMe"
-}
+export type RootStoreBaseQueries = "queryMessages" | "queryMessage" | "queryMe"
+export type RootStoreBaseMutations = "mutateMessages" | "mutateMessage" | "mutateMe"
 
 /**
 * Store, managing, among others, all the objects received through graphQL

--- a/examples/4-apollo-tutorial/client/src/models/RootStore.base.js
+++ b/examples/4-apollo-tutorial/client/src/models/RootStore.base.js
@@ -15,14 +15,18 @@ import { UserModel } from "./UserModel"
 import { userModelPrimitives, UserModelSelector } from "./UserModel.base"
 
 
+
+
+
+
 /**
 * Store, managing, among others, all the objects received through graphQL
 */
 export const RootStoreBase = MSTGQLStore
   .named("RootStore")
-  .extend(configureStoreMixin([['LaunchConnection', () => LaunchConnectionModel], ['Launch', () => LaunchModel], ['Mission', () => MissionModel], ['Rocket', () => RocketModel], ['User', () => UserModel]], ['Launch', 'Rocket', 'User']))
+  .extend(configureStoreMixin([['LaunchConnection', () => LaunchConnectionModel], ['Launch', () => LaunchModel], ['Mission', () => MissionModel], ['Rocket', () => RocketModel], ['User', () => UserModel]], ['Launch', 'Rocket', 'User'], "js"))
   .props({
-    launchs: types.optional(types.map(types.late(() => LaunchModel)), {}),
+    launches: types.optional(types.map(types.late(() => LaunchModel)), {}),
     rockets: types.optional(types.map(types.late(() => RocketModel)), {}),
     users: types.optional(types.map(types.late(() => UserModel)), {})
   })

--- a/examples/5-nextjs/src/models/RootStore.base.ts
+++ b/examples/5-nextjs/src/models/RootStore.base.ts
@@ -17,12 +17,30 @@ type Refs = {
   users: ObservableMap<string, UserModelType>
 }
 
+
+/**
+* Enums for the names of base graphql actions
+*/
+
+export enum RootStoreBaseQueries {
+queryTodos="queryTodos",
+queryDoneTodos="queryDoneTodos",
+queryUser="queryUser",
+queryUsers="queryUsers"
+}
+export enum RootStoreBaseMutations {
+mutateTodos="mutateTodos",
+mutateDoneTodos="mutateDoneTodos",
+mutateUser="mutateUser",
+mutateUsers="mutateUsers"
+}
+
 /**
 * Store, managing, among others, all the objects received through graphQL
 */
 export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
   .named("RootStore")
-  .extend(configureStoreMixin([['Todo', () => TodoModel], ['User', () => UserModel]], ['Todo', 'User']))
+  .extend(configureStoreMixin([['Todo', () => TodoModel], ['User', () => UserModel]], ['Todo', 'User'], "js"))
   .props({
     todos: types.optional(types.map(types.late((): any => TodoModel)), {}),
     users: types.optional(types.map(types.late((): any => UserModel)), {})

--- a/examples/5-nextjs/src/models/RootStore.base.ts
+++ b/examples/5-nextjs/src/models/RootStore.base.ts
@@ -21,7 +21,6 @@ type Refs = {
 /**
 * Enums for the names of base graphql actions
 */
-
 export enum RootStoreBaseQueries {
 queryTodos="queryTodos",
 queryDoneTodos="queryDoneTodos",

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -685,11 +685,13 @@ ${rootTypes
     const enumContent = queries.fields
       .map(({ name }) => {
         const queryName = `${methodPrefix}${toFirstUpper(name)}`
-        return `"${queryName}"`
+        return `${queryName}="${queryName}"`
       })
-      .join(" | ")
+      .join(",\n")
     if (enumContent === "") return
-    return `export type RootStoreBase${gqlPlural} = ${enumContent}`
+    return `export enum RootStoreBase${gqlPlural} {
+${enumContent}
+}`
   }
 
   function generateQueries() {

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -685,13 +685,11 @@ ${rootTypes
     const enumContent = queries.fields
       .map(({ name }) => {
         const queryName = `${methodPrefix}${toFirstUpper(name)}`
-        return `${queryName}="${queryName}"`
+        return `"${queryName}"`
       })
-      .join(",\n")
+      .join(" | ")
     if (enumContent === "") return
-    return `export enum RootStoreBase${gqlPlural} {
-${enumContent}
-}`
+    return `export type RootStoreBase${gqlPlural} = ${enumContent}`
   }
 
   function generateQueries() {

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -629,8 +629,7 @@ ${rootTypes
 ${ifTS(`
 /**
 * Enums for the names of base graphql actions
-*/
-`)}
+*/`)}
 ${ifTS(generateGraphQLActionsEnum("Query", "Queries", "query"))}
 ${ifTS(generateGraphQLActionsEnum("Mutation", "Mutations", "mutate"))}
 

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -629,8 +629,8 @@ ${rootTypes
 /**
 * Enums for the names of base graphql actions
 */
-${generateGraphQLActionsEnum("Query", "Queries", "query")}
-${generateGraphQLActionsEnum("Mutation", "Mutations", "mutate")}
+${ifTS(generateGraphQLActionsEnum("Query", "Queries", "query"))}
+${ifTS(generateGraphQLActionsEnum("Mutation", "Mutations", "mutate"))}
 
 /**
 * Store, managing, among others, all the objects received through graphQL

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -627,6 +627,12 @@ ${rootTypes
   .join(",\n")}
 }\n\n`)}\
 /**
+* Enums for the names of base graphql actions
+*/
+${generateGraphQLActionsEnum("Query", "Queries")}
+${generateGraphQLActionsEnum("Mutation", "Mutations")}
+
+/**
 * Store, managing, among others, all the objects received through graphQL
 */
 export const RootStoreBase = ${ifTS("withTypedRefs<Refs>()(")}${
@@ -656,6 +662,36 @@ ${rootTypes
 `
     generateFile("RootStore", entryFile)
     generateFile("RootStore.base", modelFile, true)
+  }
+
+  /**
+   * A func to generate enums that are the names of the graphql actions in the RootStore.base
+   * Like:
+   * export enum RootStoreBaseQueries {
+   *    queryMessages="queryMessages",
+   *    queryMessage="queryMessage",
+   *    queryMe="queryMe"
+   * }
+   *
+   *
+   * @param {*} gqlType Query | Mutation
+   * @param {*} gqlPrefix query | mutation
+   */
+  function generateGraphQLActionsEnum(gqlType, gqlPlural) {
+    const queries = findObjectByName(
+      schema.queryType ? schema.queryType.name : gqlType
+    )
+
+    const enumContent = queries.fields
+      .map(({ name }) => {
+        const queryName = `${gqlType.toLowerCase()}${toFirstUpper(name)}`
+        return `${queryName}="${queryName}"`
+      })
+      .join(",\n")
+    if (enumContent === "") return
+    return `export enum RootStoreBase${gqlPlural} {
+${enumContent}
+}`
   }
 
   function generateQueries() {

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -629,8 +629,8 @@ ${rootTypes
 /**
 * Enums for the names of base graphql actions
 */
-${generateGraphQLActionsEnum("Query", "Queries")}
-${generateGraphQLActionsEnum("Mutation", "Mutations")}
+${generateGraphQLActionsEnum("Query", "Queries", "query")}
+${generateGraphQLActionsEnum("Mutation", "Mutations", "mutate")}
 
 /**
 * Store, managing, among others, all the objects received through graphQL
@@ -677,14 +677,14 @@ ${rootTypes
    * @param {*} gqlType Query | Mutation
    * @param {*} gqlPrefix query | mutation
    */
-  function generateGraphQLActionsEnum(gqlType, gqlPlural) {
+  function generateGraphQLActionsEnum(gqlType, gqlPlural, methodPrefix) {
     const queries = findObjectByName(
       schema.queryType ? schema.queryType.name : gqlType
     )
 
     const enumContent = queries.fields
       .map(({ name }) => {
-        const queryName = `${gqlType.toLowerCase()}${toFirstUpper(name)}`
+        const queryName = `${methodPrefix}${toFirstUpper(name)}`
         return `${queryName}="${queryName}"`
       })
       .join(",\n")

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -626,9 +626,11 @@ ${rootTypes
   )
   .join(",\n")}
 }\n\n`)}\
+${ifTS(`
 /**
 * Enums for the names of base graphql actions
 */
+`)}
 ${ifTS(generateGraphQLActionsEnum("Query", "Queries", "query"))}
 ${ifTS(generateGraphQLActionsEnum("Mutation", "Mutations", "mutate"))}
 

--- a/tests/generator/__snapshots__/generate.test.js.snap
+++ b/tests/generator/__snapshots__/generate.test.js.snap
@@ -112,6 +112,18 @@ type Refs = {
   users: ObservableMap<string, UserModelType>
 }
 
+
+/**
+* Enums for the names of base graphql actions
+*/
+
+export enum RootStoreBaseQueries {
+queryMe=\\"queryMe\\"
+}
+export enum RootStoreBaseMutations {
+mutateMe=\\"mutateMe\\"
+}
+
 /**
 * Store, managing, among others, all the objects received through graphQL
 */
@@ -426,6 +438,18 @@ type Refs = {
   possiblyEmptyBoxes: ObservableMap<string, PossiblyEmptyBoxModelType>
 }
 
+
+/**
+* Enums for the names of base graphql actions
+*/
+
+export enum RootStoreBaseQueries {
+queryMe=\\"queryMe\\"
+}
+export enum RootStoreBaseMutations {
+mutateMe=\\"mutateMe\\"
+}
+
 /**
 * Store, managing, among others, all the objects received through graphQL
 */
@@ -655,6 +679,18 @@ type Refs = {
   users: ObservableMap<string, UserModelType>
 }
 
+
+/**
+* Enums for the names of base graphql actions
+*/
+
+export enum RootStoreBaseQueries {
+queryMe=\\"queryMe\\"
+}
+export enum RootStoreBaseMutations {
+mutateMe=\\"mutateMe\\"
+}
+
 /**
 * Store, managing, among others, all the objects received through graphQL
 */
@@ -881,6 +917,18 @@ import { InterestEnum } from \\"./InterestEnum\\"
 /* The TypeScript type that explicits the refs to other models in order to prevent a circular refs issue */
 type Refs = {
   users: ObservableMap<string, UserModelType>
+}
+
+
+/**
+* Enums for the names of base graphql actions
+*/
+
+export enum RootStoreBaseQueries {
+queryMe=\\"queryMe\\"
+}
+export enum RootStoreBaseMutations {
+mutateMe=\\"mutateMe\\"
 }
 
 /**
@@ -1209,6 +1257,18 @@ type Refs = {
   repos: ObservableMap<string, RepoModelType>
 }
 
+
+/**
+* Enums for the names of base graphql actions
+*/
+
+export enum RootStoreBaseQueries {
+queryRepo=\\"queryRepo\\"
+}
+export enum RootStoreBaseMutations {
+mutateRepo=\\"mutateRepo\\"
+}
+
 /**
 * Store, managing, among others, all the objects received through graphQL
 */
@@ -1531,6 +1591,18 @@ type Refs = {
   searchresults: ObservableMap<string, SearchResultModelType>
 }
 
+
+/**
+* Enums for the names of base graphql actions
+*/
+
+export enum RootStoreBaseQueries {
+querySearch=\\"querySearch\\"
+}
+export enum RootStoreBaseMutations {
+mutateSearch=\\"mutateSearch\\"
+}
+
 /**
 * Store, managing, among others, all the objects received through graphQL
 */
@@ -1696,6 +1768,18 @@ export type MovieInput = {
 /* The TypeScript type that explicits the refs to other models in order to prevent a circular refs issue */
 type Refs = {
 
+}
+
+
+/**
+* Enums for the names of base graphql actions
+*/
+
+export enum RootStoreBaseQueries {
+querySearch=\\"querySearch\\"
+}
+export enum RootStoreBaseMutations {
+mutateSearch=\\"mutateSearch\\"
 }
 
 /**

--- a/tests/generator/__snapshots__/generate.test.js.snap
+++ b/tests/generator/__snapshots__/generate.test.js.snap
@@ -116,7 +116,6 @@ type Refs = {
 /**
 * Enums for the names of base graphql actions
 */
-
 export enum RootStoreBaseQueries {
 queryMe=\\"queryMe\\"
 }
@@ -442,7 +441,6 @@ type Refs = {
 /**
 * Enums for the names of base graphql actions
 */
-
 export enum RootStoreBaseQueries {
 queryMe=\\"queryMe\\"
 }
@@ -683,7 +681,6 @@ type Refs = {
 /**
 * Enums for the names of base graphql actions
 */
-
 export enum RootStoreBaseQueries {
 queryMe=\\"queryMe\\"
 }
@@ -923,7 +920,6 @@ type Refs = {
 /**
 * Enums for the names of base graphql actions
 */
-
 export enum RootStoreBaseQueries {
 queryMe=\\"queryMe\\"
 }
@@ -1261,7 +1257,6 @@ type Refs = {
 /**
 * Enums for the names of base graphql actions
 */
-
 export enum RootStoreBaseQueries {
 queryRepo=\\"queryRepo\\"
 }
@@ -1595,7 +1590,6 @@ type Refs = {
 /**
 * Enums for the names of base graphql actions
 */
-
 export enum RootStoreBaseQueries {
 querySearch=\\"querySearch\\"
 }
@@ -1774,7 +1768,6 @@ type Refs = {
 /**
 * Enums for the names of base graphql actions
 */
-
 export enum RootStoreBaseQueries {
 querySearch=\\"querySearch\\"
 }

--- a/tests/lib/abstractTypes/models/RootStore.base.js
+++ b/tests/lib/abstractTypes/models/RootStore.base.js
@@ -18,6 +18,12 @@ import { organizationModelPrimitives, OrganizationModelSelector } from "./Organi
 
 
 /**
+* Enums for the names of base graphql actions
+*/
+export type RootStoreBaseQueries = "querySearch" | "queryGetAllRepos"
+export type RootStoreBaseMutations = "mutateSearch" | "mutateGetAllRepos"
+
+/**
 * Store, managing, among others, all the objects received through graphQL
 */
 export const RootStoreBase = MSTGQLStore

--- a/tests/lib/abstractTypes/models/RootStore.base.js
+++ b/tests/lib/abstractTypes/models/RootStore.base.js
@@ -20,8 +20,14 @@ import { organizationModelPrimitives, OrganizationModelSelector } from "./Organi
 /**
 * Enums for the names of base graphql actions
 */
-export type RootStoreBaseQueries = "querySearch" | "queryGetAllRepos"
-export type RootStoreBaseMutations = "mutateSearch" | "mutateGetAllRepos"
+export enum RootStoreBaseQueries {
+querySearch="querySearch",
+queryGetAllRepos="queryGetAllRepos"
+}
+export enum RootStoreBaseMutations {
+mutateSearch="mutateSearch",
+mutateGetAllRepos="mutateGetAllRepos"
+}
 
 /**
 * Store, managing, among others, all the objects received through graphQL

--- a/tests/lib/abstractTypes/models/RootStore.base.js
+++ b/tests/lib/abstractTypes/models/RootStore.base.js
@@ -20,14 +20,8 @@ import { organizationModelPrimitives, OrganizationModelSelector } from "./Organi
 /**
 * Enums for the names of base graphql actions
 */
-export enum RootStoreBaseQueries {
-querySearch="querySearch",
-queryGetAllRepos="queryGetAllRepos"
-}
-export enum RootStoreBaseMutations {
-mutateSearch="mutateSearch",
-mutateGetAllRepos="mutateGetAllRepos"
-}
+
+
 
 /**
 * Store, managing, among others, all the objects received through graphQL

--- a/tests/lib/abstractTypes/models/RootStore.base.js
+++ b/tests/lib/abstractTypes/models/RootStore.base.js
@@ -17,9 +17,7 @@ import { OrganizationModel } from "./OrganizationModel"
 import { organizationModelPrimitives, OrganizationModelSelector } from "./OrganizationModel.base"
 
 
-/**
-* Enums for the names of base graphql actions
-*/
+
 
 
 

--- a/tests/lib/todos/models/RootStore.base.js
+++ b/tests/lib/todos/models/RootStore.base.js
@@ -10,12 +10,8 @@ import { todoModelPrimitives, TodoModelSelector } from "./TodoModel.base"
 /**
 * Enums for the names of base graphql actions
 */
-export enum RootStoreBaseQueries {
-queryTodos="queryTodos"
-}
-export enum RootStoreBaseMutations {
-mutateTodos="mutateTodos"
-}
+
+
 
 /**
 * Store, managing, among others, all the objects received through graphQL

--- a/tests/lib/todos/models/RootStore.base.js
+++ b/tests/lib/todos/models/RootStore.base.js
@@ -7,9 +7,7 @@ import { TodoModel } from "./TodoModel"
 import { todoModelPrimitives, TodoModelSelector } from "./TodoModel.base"
 
 
-/**
-* Enums for the names of base graphql actions
-*/
+
 
 
 

--- a/tests/lib/todos/models/RootStore.base.js
+++ b/tests/lib/todos/models/RootStore.base.js
@@ -8,6 +8,12 @@ import { todoModelPrimitives, TodoModelSelector } from "./TodoModel.base"
 
 
 /**
+* Enums for the names of base graphql actions
+*/
+export type RootStoreBaseQueries = "queryTodos"
+export type RootStoreBaseMutations = "mutateTodos"
+
+/**
 * Store, managing, among others, all the objects received through graphQL
 */
 export const RootStoreBase = MSTGQLStore

--- a/tests/lib/todos/models/RootStore.base.js
+++ b/tests/lib/todos/models/RootStore.base.js
@@ -10,8 +10,12 @@ import { todoModelPrimitives, TodoModelSelector } from "./TodoModel.base"
 /**
 * Enums for the names of base graphql actions
 */
-export type RootStoreBaseQueries = "queryTodos"
-export type RootStoreBaseMutations = "mutateTodos"
+export enum RootStoreBaseQueries {
+queryTodos="queryTodos"
+}
+export enum RootStoreBaseMutations {
+mutateTodos="mutateTodos"
+}
 
 /**
 * Store, managing, among others, all the objects received through graphQL


### PR DESCRIPTION
- Adding types for the base graphql actions so they can be used to dynamically call them.

i.e. I want to call these actions from the RootStore with their string name like:

```
self[graphqlActionName](......args and stuff)
```

This currently complains about TS and doesn't have autocomplete for the possible action names I can call. This PR aims to add types so that it is possible to type these actions.