### PR TITLE
Exclude fields from type generation that we exclude in action generation

### DIFF
--- a/examples/2-scaffolding/src/models/RootStore.base.ts
+++ b/examples/2-scaffolding/src/models/RootStore.base.ts
@@ -28,7 +28,6 @@ type Refs = {
 * Enums for the names of base graphql actions
 */
 export enum RootStoreBaseQueries {
-queryQuery="queryQuery",
 queryPokemons="queryPokemons",
 queryPokemon="queryPokemon"
 }


### PR DESCRIPTION
- Don't create types for actions that are skipped in generation

I ran all of the examples and tests (no snapshot changes)