### PR TITLE
Add Model suffix to MST enum model to avoid clash with TS enum name

### DIFF
--- a/generator/generate.js
+++ b/generator/generate.js
@@ -165,7 +165,7 @@ export const ModelBase = MSTGQLObject
   function handleEnumType(type) {
     const name = type.name
     const enumPostfix = !name.toLowerCase().endsWith("enum") ? "Enum" : ""
-    toExport.push(name + enumPostfix)
+    toExport.push(name + enumPostfix + "Model")
 
     const tsType =
       format === "ts"
@@ -188,12 +188,12 @@ ${tsType}
 /**
 * ${name}${optPrefix("\n *\n * ", sanitizeComment(type.description))}
 */
-export const ${name}${enumPostfix} = ${handleEnumTypeCore(type)}
+export const ${name}${enumPostfix}Model = ${handleEnumTypeCore(type)}
 `
     if (format === "ts") {
       enumTypes.push(type.name)
     }
-    generateFile(name + enumPostfix, contents, true)
+    generateFile(name + enumPostfix + "Model", contents, true)
   }
 
   function handleEnumTypeCore(type) {
@@ -415,7 +415,9 @@ ${generateFragments(name, primitiveFields, nonPrimitiveFields)}
           primitiveFields.push(fieldName)
           const enumType =
             fieldType.name +
-            (!fieldType.name.toLowerCase().endsWith("enum") ? "Enum" : "")
+            (!fieldType.name.toLowerCase().endsWith("enum")
+              ? "EnumModel"
+              : "Model")
           if (type.kind !== "UNION" && type.kind !== "INTERFACE") {
             // TODO: import again when enums in query builders are supported
             addImport(enumType, enumType)
@@ -600,7 +602,7 @@ ${enumTypes
   .map(
     t =>
       `\nimport { ${t} } from "./${t}${
-        !t.toLowerCase().endsWith("enum") ? "Enum" : ""
+        !t.toLowerCase().endsWith("enum") ? "EnumModel" : "Model"
       }${importPostFix}"`
   )
   .join("")}

--- a/tests/generator/__snapshots__/generate.test.js.snap
+++ b/tests/generator/__snapshots__/generate.test.js.snap
@@ -514,9 +514,9 @@ export const ModelBase = MSTGQLObject
 import { types } from \\"mobx-state-tree\\"
 import { QueryBuilder } from \\"mst-gql\\"
 import { ModelBase } from \\"./ModelBase\\"
-import { RoleEnum } from \\"./RoleEnum\\"
+import { RoleEnumModel } from \\"./RoleEnumModel\\"
 import { RootStoreType } from \\"./index\\"
-import { interest_enum } from \\"./interest_enum\\"
+import { interest_enumModel } from \\"./interest_enumModel\\"
 
 
 /**
@@ -530,8 +530,8 @@ export const UserModelBase = ModelBase
     id: types.identifier,
     name: types.union(types.undefined, types.string),
     avatar: types.union(types.undefined, types.string),
-    role: types.union(types.undefined, RoleEnum),
-    interest: types.union(types.undefined, interest_enum),
+    role: types.union(types.undefined, RoleEnumModel),
+    interest: types.union(types.undefined, interest_enumModel),
   })
   .views(self => ({
     get store() {
@@ -579,7 +579,7 @@ export const UserModel = UserModelBase
     false,
   ],
   Array [
-    "RoleEnum",
+    "RoleEnumModel",
     "/* This is a mst-gql generated file, don't modify it manually */
 /* eslint-disable */
 /* tslint:disable */
@@ -598,7 +598,7 @@ AUTHOR=\\"AUTHOR\\"
 /**
 * Role
 */
-export const RoleEnum = types.enumeration(\\"Role\\", [
+export const RoleEnumModel = types.enumeration(\\"Role\\", [
         \\"USER\\",
   \\"ADMIN\\",
   \\"AUTHOR\\",
@@ -607,7 +607,7 @@ export const RoleEnum = types.enumeration(\\"Role\\", [
     true,
   ],
   Array [
-    "interest_enum",
+    "interest_enumModel",
     "/* This is a mst-gql generated file, don't modify it manually */
 /* eslint-disable */
 /* tslint:disable */
@@ -626,7 +626,7 @@ COOKING=\\"COOKING\\"
 /**
 * interest_enum
 */
-export const interest_enum = types.enumeration(\\"interest_enum\\", [
+export const interest_enumModel = types.enumeration(\\"interest_enum\\", [
         \\"READING\\",
   \\"SPORTS\\",
   \\"COOKING\\",
@@ -663,8 +663,8 @@ import { MSTGQLStore, configureStoreMixin, QueryOptions, withTypedRefs } from \\
 import { UserModel, UserModelType } from \\"./UserModel\\"
 import { userModelPrimitives, UserModelSelector } from \\"./UserModel.base\\"
 
-import { Role } from \\"./RoleEnum\\"
-import { interest_enum } from \\"./interest_enum\\"
+import { Role } from \\"./RoleEnumModel\\"
+import { interest_enum } from \\"./interest_enumModel\\"
 
 /* The TypeScript type that explicits the refs to other models in order to prevent a circular refs issue */
 type Refs = {
@@ -722,8 +722,8 @@ export const useQuery = createUseQueryHook(StoreContext, React)
 /* tslint:disable */
 
 export * from \\"./UserModel\\"
-export * from \\"./RoleEnum\\"
-export * from \\"./interest_enum\\"
+export * from \\"./RoleEnumModel\\"
+export * from \\"./interest_enumModel\\"
 export * from \\"./RootStore\\"
 export * from \\"./reactUtils\\"
 ",
@@ -751,8 +751,8 @@ export const ModelBase = MSTGQLObject
 import { types } from \\"mobx-state-tree\\"
 import { QueryBuilder } from \\"mst-gql\\"
 import { ModelBase } from \\"./ModelBase\\"
-import { InterestEnum } from \\"./InterestEnum\\"
-import { RoleEnum } from \\"./RoleEnum\\"
+import { InterestEnumModel } from \\"./InterestEnumModel\\"
+import { RoleEnumModel } from \\"./RoleEnumModel\\"
 import { RootStoreType } from \\"./index\\"
 
 
@@ -767,8 +767,8 @@ export const UserModelBase = ModelBase
     id: types.identifier,
     name: types.union(types.undefined, types.string),
     avatar: types.union(types.undefined, types.string),
-    role: types.union(types.undefined, RoleEnum),
-    interest: types.union(types.undefined, InterestEnum),
+    role: types.union(types.undefined, RoleEnumModel),
+    interest: types.union(types.undefined, InterestEnumModel),
   })
   .views(self => ({
     get store() {
@@ -816,7 +816,7 @@ export const UserModel = UserModelBase
     false,
   ],
   Array [
-    "RoleEnum",
+    "RoleEnumModel",
     "/* This is a mst-gql generated file, don't modify it manually */
 /* eslint-disable */
 /* tslint:disable */
@@ -835,7 +835,7 @@ AUTHOR=\\"AUTHOR\\"
 /**
 * Role
 */
-export const RoleEnum = types.enumeration(\\"Role\\", [
+export const RoleEnumModel = types.enumeration(\\"Role\\", [
         \\"USER\\",
   \\"ADMIN\\",
   \\"AUTHOR\\",
@@ -844,7 +844,7 @@ export const RoleEnum = types.enumeration(\\"Role\\", [
     true,
   ],
   Array [
-    "InterestEnum",
+    "InterestEnumModel",
     "/* This is a mst-gql generated file, don't modify it manually */
 /* eslint-disable */
 /* tslint:disable */
@@ -863,7 +863,7 @@ COOKING=\\"COOKING\\"
 /**
 * InterestEnum
 */
-export const InterestEnum = types.enumeration(\\"InterestEnum\\", [
+export const InterestEnumModel = types.enumeration(\\"InterestEnum\\", [
         \\"READING\\",
   \\"SPORTS\\",
   \\"COOKING\\",
@@ -900,8 +900,8 @@ import { MSTGQLStore, configureStoreMixin, QueryOptions, withTypedRefs } from \\
 import { UserModel, UserModelType } from \\"./UserModel\\"
 import { userModelPrimitives, UserModelSelector } from \\"./UserModel.base\\"
 
-import { Role } from \\"./RoleEnum\\"
-import { InterestEnum } from \\"./InterestEnum\\"
+import { Role } from \\"./RoleEnumModel\\"
+import { InterestEnum } from \\"./InterestEnumModel\\"
 
 /* The TypeScript type that explicits the refs to other models in order to prevent a circular refs issue */
 type Refs = {
@@ -959,8 +959,8 @@ export const useQuery = createUseQueryHook(StoreContext, React)
 /* tslint:disable */
 
 export * from \\"./UserModel\\"
-export * from \\"./RoleEnum\\"
-export * from \\"./InterestEnum\\"
+export * from \\"./RoleEnumModel\\"
+export * from \\"./InterestEnumModel\\"
 export * from \\"./RootStore\\"
 export * from \\"./reactUtils\\"
 ",

--- a/tests/generator/generate.test.js
+++ b/tests/generator/generate.test.js
@@ -260,7 +260,7 @@ type Query {
 
   expect(findFile(output, "UserModel")).toBeTruthy()
 
-  const roleEnumFile = findFile(output, "RoleEnum")
+  const roleEnumFile = findFile(output, "RoleEnumModel")
   expect(roleEnumFile).toBeTruthy()
 
   // TS type is plain Role
@@ -269,11 +269,11 @@ type Query {
   expect(
     hasFileContentExact(
       roleEnumFile,
-      'export const RoleEnum = types.enumeration("Role"'
+      'export const RoleEnumModel = types.enumeration("Role"'
     )
   ).toBeTruthy()
 
-  const interestEnumFile = findFile(output, "interest_enum")
+  const interestEnumFile = findFile(output, "interest_enumModel")
   expect(interestEnumFile).toBeTruthy()
   // TS type is plain interest_enum
   expect(
@@ -283,7 +283,7 @@ type Query {
   expect(
     hasFileContentExact(
       interestEnumFile,
-      'export const interest_enum = types.enumeration("interest_enum"'
+      'export const interest_enumModel = types.enumeration("interest_enum"'
     )
   ).toBeTruthy()
 })
@@ -323,17 +323,17 @@ type Query {
 
   expect(findFile(output, "UserModel")).toBeTruthy()
 
-  const roleEnumFile = findFile(output, "RoleEnum")
+  const roleEnumFile = findFile(output, "RoleEnumModel")
   expect(roleEnumFile).toBeTruthy()
   expect(hasFileContentExact(roleEnumFile, "export enum Role {")).toBeTruthy()
   expect(
     hasFileContentExact(
       roleEnumFile,
-      'export const RoleEnum = types.enumeration("Role"'
+      'export const RoleEnumModel = types.enumeration("Role"'
     )
   ).toBeTruthy()
 
-  const interestEnumFile = findFile(output, "InterestEnum")
+  const interestEnumFile = findFile(output, "InterestEnumModel")
   console.log("interestEnumFile", interestEnumFile)
   expect(interestEnumFile).toBeTruthy()
   expect(
@@ -342,7 +342,7 @@ type Query {
   expect(
     hasFileContentExact(
       interestEnumFile,
-      'export const InterestEnum = types.enumeration("InterestEnum"'
+      'export const InterestEnumModel = types.enumeration("InterestEnum"'
     )
   ).toBeTruthy()
 })


### PR DESCRIPTION
Also the file names for enums will now end with Model, which makes naming
of files the same for all types.

This is to fix enum issue in #201