### PR TITLE
Add optional filter option to localStorageMixin 

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,13 +633,14 @@ For examples, see the sections [Loading and rendering your first data](#loading-
 
 ## `localStorageMixin`
 
-The `localStorageMixin` can be used to automatically save the full state of the `RootStore`. By default the store is saved after every change, but throttle to be saved once per 5 seconds. (The reason for the throttling is that, although snapshotting is cheap, serializing a a snapshot to a string is expensive).
+The `localStorageMixin` can be used to automatically save the full state of the `RootStore`. By default the store is saved after every change, but throttle to be saved once per 5 seconds. (The reason for the throttling is that, although snapshotting is cheap, serializing a a snapshot to a string is expensive). If you only want to persist parts of the store you can use the `filter` option to filter which keys that should be stored.
 
 Options:
 
 - `storage` (the storage object to use. Defaults to `window.localStorage`)
 - `throttle` (in milliseconds)
 - `storageKey` (the key to be used to store in the local storage).
+- `filter` (an optional array of string keys that determines which data that will be stored to local storage)
 
 Example:
 
@@ -650,6 +651,7 @@ const RootStore = RootStoreBase.extend(
   localStorageMixin({
     throttle: 1000,
     storageKey: "appFluff"
+    filter: ['todos', 'key.subkey']
   })
 )
 ```

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "fast-json-stable-stringify": "^2.1.0",
     "graphql": "^14.6.0",
     "graphql-request": "^1.8.2",
+    "lodash": "^4.17.15",
     "pluralize": "^8.0.0",
     "throttle-debounce": "^2.1.0"
   },
@@ -62,6 +63,7 @@
     "@babel/register": "^7.4.4",
     "@types/graphql": "^14.2.3",
     "@types/jest": "^24.0.16",
+    "@types/lodash": "^4.14.155",
     "@types/pluralize": "^0.0.29",
     "@types/react": "^16.8.24",
     "@types/react-dom": "^16.8.5",

--- a/src/localStorageMixin.ts
+++ b/src/localStorageMixin.ts
@@ -7,8 +7,8 @@ import {
 } from "mobx-state-tree"
 
 import { throttle } from "throttle-debounce"
+import pick from "lodash/pick"
 
-// TODO: support skipping parts of the store, with a key filter for example
 type LocalStorageMixinOptions = {
   storage?: {
     getItem(key: string): string | null | Promise<string | null>
@@ -16,6 +16,7 @@ type LocalStorageMixinOptions = {
   }
   throttle?: number // How often the snapshot is written to local storage
   storageKey?: string
+  filter?: string[]
 }
 export function localStorageMixin(options: LocalStorageMixinOptions = {}) {
   const storage = options.storage || window.localStorage
@@ -41,6 +42,9 @@ export function localStorageMixin(options: LocalStorageMixinOptions = {}) {
           onSnapshot(
             self,
             throttle(throttleInterval, (data: any) => {
+              if (options.filter) {
+                data = pick(data, options.filter)
+              }
               storage.setItem(storageKey, JSON.stringify(data))
             })
           )

--- a/yarn.lock
+++ b/yarn.lock
@@ -1375,6 +1375,11 @@
   dependencies:
     jest-diff "^24.3.0"
 
+"@types/lodash@^4.14.155":
+  version "4.14.155"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.155.tgz#e2b4514f46a261fd11542e47519c20ebce7bc23a"
+  integrity sha512-vEcX7S7aPhsBCivxMwAANQburHBtfN9RdyXFk84IJmu2Z4Hkg1tOFgaslRiEqqvoLtbCBi6ika1EMspE+NZ9Lg==
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"


### PR DESCRIPTION
Copied from #243

Allows the user to filter which data to store in local storage

Uses lodash/pick since it allows to use dot notation for filtering nested data which is nice. But maybe there's a better alternative?