### PR TITLE
Union type in actions

### DIFF
--- a/examples/3-twitter-clone/src/app/models/RootStore.base.ts
+++ b/examples/3-twitter-clone/src/app/models/RootStore.base.ts
@@ -5,10 +5,10 @@ import { ObservableMap } from "mobx"
 import { types } from "mobx-state-tree"
 import { MSTGQLStore, configureStoreMixin, QueryOptions, withTypedRefs } from "mst-gql"
 
-import { MessageModel, MessageModelType } from "./MessageModel"
-import { messageModelPrimitives, MessageModelSelector } from "./MessageModel.base"
 import { UserModel, UserModelType } from "./UserModel"
 import { userModelPrimitives, UserModelSelector } from "./UserModel.base"
+import { MessageModel, MessageModelType } from "./MessageModel"
+import { messageModelPrimitives, MessageModelSelector } from "./MessageModel.base"
 
 
 /* The TypeScript type that explicits the refs to other models in order to prevent a circular refs issue */
@@ -22,6 +22,7 @@ type Refs = {
 * Enums for the names of base graphql actions
 */
 export enum RootStoreBaseQueries {
+querySearch="querySearch",
 queryMessages="queryMessages",
 queryMessage="queryMessage",
 queryMe="queryMe"
@@ -37,12 +38,17 @@ mutatePostTweet="mutatePostTweet"
 */
 export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
   .named("RootStore")
-  .extend(configureStoreMixin([['Message', () => MessageModel], ['User', () => UserModel]], ['Message', 'User'], "js"))
+  .extend(configureStoreMixin([['User', () => UserModel], ['Message', () => MessageModel]], ['Message', 'User'], "js"))
   .props({
     messages: types.optional(types.map(types.late((): any => MessageModel)), {}),
     users: types.optional(types.map(types.late((): any => UserModel)), {})
   })
   .actions(self => ({
+    querySearch(variables: { searchText: string }, resultSelector: string | ((qb: SearchResultModelSelector) => SearchResultModelSelector) = searchResultModelPrimitives.toString(), options: QueryOptions = {}) {
+      return self.query<{ search: SearchResultModelType[]}>(`query search($searchText: String!) { search(searchText: $searchText) {
+        ${typeof resultSelector === "function" ? resultSelector(new SearchResultModelSelector()).toString() : resultSelector}
+      } }`, variables, options)
+    },
     queryMessages(variables: { offset?: string, count?: number, replyTo?: string }, resultSelector: string | ((qb: MessageModelSelector) => MessageModelSelector) = messageModelPrimitives.toString(), options: QueryOptions = {}) {
       return self.query<{ messages: MessageModelType[]}>(`query messages($offset: ID, $count: Int, $replyTo: ID) { messages(offset: $offset, count: $count, replyTo: $replyTo) {
         ${typeof resultSelector === "function" ? resultSelector(new MessageModelSelector()).toString() : resultSelector}

--- a/examples/3-twitter-clone/src/app/models/RootStore.base.ts
+++ b/examples/3-twitter-clone/src/app/models/RootStore.base.ts
@@ -10,6 +10,8 @@ import { userModelPrimitives, UserModelSelector } from "./UserModel.base"
 import { MessageModel, MessageModelType } from "./MessageModel"
 import { messageModelPrimitives, MessageModelSelector } from "./MessageModel.base"
 
+import { searchResultModelPrimitives, SearchResultModelSelector , SearchResultUnion } from "./SearchResultModelSelector"
+
 
 /* The TypeScript type that explicits the refs to other models in order to prevent a circular refs issue */
 type Refs = {

--- a/examples/3-twitter-clone/src/app/models/RootStore.base.ts
+++ b/examples/3-twitter-clone/src/app/models/RootStore.base.ts
@@ -10,7 +10,7 @@ import { userModelPrimitives, UserModelSelector } from "./UserModel.base"
 import { MessageModel, MessageModelType } from "./MessageModel"
 import { messageModelPrimitives, MessageModelSelector } from "./MessageModel.base"
 
-import { searchResultModelPrimitives, SearchResultModelSelector , SearchResultUnion } from "./SearchResultModelSelector"
+import { searchResultModelPrimitives, SearchResultModelSelector , SearchResultUnion } from "./"
 
 
 /* The TypeScript type that explicits the refs to other models in order to prevent a circular refs issue */

--- a/examples/3-twitter-clone/src/app/models/RootStore.base.ts
+++ b/examples/3-twitter-clone/src/app/models/RootStore.base.ts
@@ -47,7 +47,7 @@ export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
   })
   .actions(self => ({
     querySearch(variables: { searchText: string }, resultSelector: string | ((qb: SearchResultModelSelector) => SearchResultModelSelector) = searchResultModelPrimitives.toString(), options: QueryOptions = {}) {
-      return self.query<{ search: SearchResultModelType[]}>(`query search($searchText: String!) { search(searchText: $searchText) {
+      return self.query<{ search: SearchResultUnion[]}>(`query search($searchText: String!) { search(searchText: $searchText) {
         ${typeof resultSelector === "function" ? resultSelector(new SearchResultModelSelector()).toString() : resultSelector}
       } }`, variables, options)
     },

--- a/examples/3-twitter-clone/src/app/models/SearchResultModelSelector.ts
+++ b/examples/3-twitter-clone/src/app/models/SearchResultModelSelector.ts
@@ -3,8 +3,12 @@
 /* tslint:disable */
 
 import { QueryBuilder } from "mst-gql"
+import { MessageModelType } from "./MessageModel"
 import { MessageModelSelector, messageModelPrimitives } from "./MessageModel.base"
+import { UserModelType } from "./UserModel"
 import { UserModelSelector, userModelPrimitives } from "./UserModel.base"
+
+export type SearchResultUnion = UserModelType | MessageModelType
 
 export class SearchResultModelSelector extends QueryBuilder {
   user(builder?: string | UserModelSelector | ((selector: UserModelSelector) => UserModelSelector)) { return this.__inlineFragment(`User`, UserModelSelector, builder) }

--- a/examples/3-twitter-clone/src/app/models/SearchResultModelSelector.ts
+++ b/examples/3-twitter-clone/src/app/models/SearchResultModelSelector.ts
@@ -1,0 +1,18 @@
+/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+import { QueryBuilder } from "mst-gql"
+import { MessageModelSelector, messageModelPrimitives } from "./MessageModel.base"
+import { UserModelSelector, userModelPrimitives } from "./UserModel.base"
+
+export class SearchResultModelSelector extends QueryBuilder {
+  user(builder?: string | UserModelSelector | ((selector: UserModelSelector) => UserModelSelector)) { return this.__inlineFragment(`User`, UserModelSelector, builder) }
+  message(builder?: string | MessageModelSelector | ((selector: MessageModelSelector) => MessageModelSelector)) { return this.__inlineFragment(`Message`, MessageModelSelector, builder) }
+}
+export function selectFromSearchResult() {
+  return new SearchResultModelSelector()
+}
+
+// provides all primitive fields of union member types combined together
+export const searchResultModelPrimitives = selectFromSearchResult().user(userModelPrimitives).message(messageModelPrimitives)

--- a/examples/3-twitter-clone/src/app/models/index.ts
+++ b/examples/3-twitter-clone/src/app/models/index.ts
@@ -2,7 +2,8 @@
 /* eslint-disable */
 /* tslint:disable */
 
-export * from "./MessageModel"
+export * from "./SearchResultModelSelector"
 export * from "./UserModel"
+export * from "./MessageModel"
 export * from "./RootStore"
 export * from "./reactUtils"

--- a/examples/3-twitter-clone/src/app/models/reactUtils.ts
+++ b/examples/3-twitter-clone/src/app/models/reactUtils.ts
@@ -4,7 +4,7 @@
 
 import { createStoreContext, createUseQueryHook } from "mst-gql"
 import * as React from "react"
-import { RootStore, RootStoreType } from "./RootStore"
+import { RootStoreType } from "./RootStore"
 
 export const StoreContext = createStoreContext<RootStoreType>(React)
 

--- a/examples/3-twitter-clone/src/server/models/RootStore.base.ts
+++ b/examples/3-twitter-clone/src/server/models/RootStore.base.ts
@@ -9,6 +9,7 @@ import { UserModel, UserModelType } from "./UserModel"
 import { MessageModel, MessageModelType } from "./MessageModel"
 
 
+
 /* The TypeScript type that explicits the refs to other models in order to prevent a circular refs issue */
 type Refs = {
   messages: ObservableMap<string, MessageModelType>,

--- a/examples/3-twitter-clone/src/server/models/RootStore.base.ts
+++ b/examples/3-twitter-clone/src/server/models/RootStore.base.ts
@@ -5,8 +5,8 @@ import { ObservableMap } from "mobx"
 import { types } from "mobx-state-tree"
 import { MSTGQLStore, configureStoreMixin, QueryOptions, withTypedRefs } from "mst-gql"
 
-import { MessageModel, MessageModelType } from "./MessageModel"
 import { UserModel, UserModelType } from "./UserModel"
+import { MessageModel, MessageModelType } from "./MessageModel"
 
 
 /* The TypeScript type that explicits the refs to other models in order to prevent a circular refs issue */
@@ -20,6 +20,7 @@ type Refs = {
 * Enums for the names of base graphql actions
 */
 export enum RootStoreBaseQueries {
+querySearch="querySearch",
 queryMessages="queryMessages",
 queryMessage="queryMessage",
 queryMe="queryMe"
@@ -35,7 +36,7 @@ mutatePostTweet="mutatePostTweet"
 */
 export const RootStoreBase = withTypedRefs<Refs>()(types.model()
   .named("RootStore")
-  .extend(configureStoreMixin([['Message', () => MessageModel], ['User', () => UserModel]], ['Message', 'User'], "js"))
+  .extend(configureStoreMixin([['User', () => UserModel], ['Message', () => MessageModel]], ['Message', 'User'], "js"))
   .props({
     messages: types.optional(types.map(types.late((): any => MessageModel)), {}),
     users: types.optional(types.map(types.late((): any => UserModel)), {})

--- a/examples/3-twitter-clone/src/server/models/index.ts
+++ b/examples/3-twitter-clone/src/server/models/index.ts
@@ -2,6 +2,6 @@
 /* eslint-disable */
 /* tslint:disable */
 
-export * from "./MessageModel"
 export * from "./UserModel"
+export * from "./MessageModel"
 export * from "./RootStore"

--- a/examples/3-twitter-clone/src/server/schema.graphql
+++ b/examples/3-twitter-clone/src/server/schema.graphql
@@ -12,6 +12,7 @@ type Message {
   replyTo: Message
 }
 type Query {
+  search(searchText: String!): [SearchResult!]
   messages(offset: ID, count: Int, replyTo: ID): [Message]
   message(id: ID!): Message
   me: User
@@ -24,3 +25,5 @@ type Mutation {
   like(msg: ID!, user: ID!): Message
   postTweet(text: String!, user: ID!, replyTo: ID): Message
 }
+
+union SearchResult = User | Message

--- a/examples/3-twitter-clone/src/server/schema.ts
+++ b/examples/3-twitter-clone/src/server/schema.ts
@@ -8,6 +8,16 @@ const store = RootStore.create()
 
 export const resolvers = {
   Query: {
+    search: (_, { searchText }) => {
+      const messages = store.messages
+        .values()
+        .filter(message => message.text.includes(searchText))
+      const user = store.users
+        .values()
+        .filter(user => user.name.includes(searchText))
+
+      return [...messages, ...user]
+    },
     messages: (_, { offset, count, replyTo }) =>
       store.allMessages(offset, count, replyTo),
     message: (_, { id }) => store.getMessage(id),

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -323,9 +323,7 @@ ${generateFragments(name, primitiveFields, nonPrimitiveFields)}
     const {
       primitiveFields,
       nonPrimitiveFields,
-      imports,
-      modelProperties,
-      refs
+      imports
     } = resolveFieldsAndImports(type, fileName)
 
     interfaceOrUnionType &&
@@ -350,7 +348,6 @@ ${generateFragments(name, primitiveFields, nonPrimitiveFields)}
           )
         }
       })
-
 
     let contents = header + "\n\n"
     contents += 'import { QueryBuilder } from "mst-gql"\n'

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -820,9 +820,9 @@ ${enumContent}
             : `<{ ${name}: ${
                 isScalar
                   ? `${printTsPrimitiveType(type.name)} `
-                  : `${returnType.name}${modelTypePostfix}${
-                      returnsList ? "[]" : ""
-                    }`
+                  : `${returnType.name}${
+                      returnType.kind === "UNION" ? "Union" : modelTypePostfix
+                    }${returnsList ? "[]" : ""}`
               }}>`
 
         const formalArgs =

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -321,11 +321,14 @@ ${generateFragments(name, primitiveFields, nonPrimitiveFields)}
     const {
       primitiveFields,
       nonPrimitiveFields,
-      imports
+      imports,
+      modelProperties,
+      refs
     } = resolveFieldsAndImports(type, fileName)
 
     interfaceOrUnionType &&
       interfaceOrUnionType.ofTypes.forEach(t => {
+        /** Base file imports */
         const toBeImported = [`${t.name}ModelSelector`]
         if (isUnion) toBeImported.push(`${toFirstLower(t.name)}ModelPrimitives`)
         addImportToMap(
@@ -334,11 +337,31 @@ ${generateFragments(name, primitiveFields, nonPrimitiveFields)}
           `${t.name}Model.base`,
           ...toBeImported
         )
+
+        /** Imports from core model */
+        if (isUnion) {
+          addImportToMap(
+            imports,
+            fileName,
+            `${t.name}Model`,
+            `${t.name}ModelType`
+          )
+        }
       })
+
 
     let contents = header + "\n\n"
     contents += 'import { QueryBuilder } from "mst-gql"\n'
     contents += printRelativeImports(imports)
+
+    if (isUnion) {
+      contents += `export type ${
+        interfaceOrUnionType.name
+      }Union = ${interfaceOrUnionType.ofTypes
+        .map(unionModel => `${unionModel.name}ModelType`)
+        .join(" | ")}\n\n`
+    }
+
     contents += generateFragments(
       type.name,
       primitiveFields,

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -340,6 +340,7 @@ ${generateFragments(name, primitiveFields, nonPrimitiveFields)}
 
         /** Imports from core model */
         if (isUnion) {
+          // Import <model>ModelType from the core file to be used in the TS union type
           addImportToMap(
             imports,
             fileName,
@@ -353,12 +354,15 @@ ${generateFragments(name, primitiveFields, nonPrimitiveFields)}
     contents += 'import { QueryBuilder } from "mst-gql"\n'
     contents += printRelativeImports(imports)
 
+    // Add the correct type for a TS union to the exports
     if (isUnion) {
-      contents += `export type ${
-        interfaceOrUnionType.name
-      }Union = ${interfaceOrUnionType.ofTypes
-        .map(unionModel => `${unionModel.name}ModelType`)
-        .join(" | ")}\n\n`
+      contents += ifTS(
+        `export type ${
+          interfaceOrUnionType.name
+        }Union = ${interfaceOrUnionType.ofTypes
+          .map(unionModel => `${unionModel.name}ModelType`)
+          .join(" | ")}\n\n`
+      )
     }
 
     contents += generateFragments(

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -38,6 +38,7 @@ function generate(
 
   const files = [] // [[name, contents]]
   const objectTypes = [] // all known OBJECT types for which MST classes are generated
+  const unionTypes = [] // all known UNION types for which ModelSelector classes are generated
   const origObjectTypes = [] // all known OBJECT types for which MST classes are generated
   const inputTypes = [] // all known INPUT_OBJECT types for which MST classes are generated
   const knownTypes = [] // all known types (including enums and such) for which MST classes are generated
@@ -317,6 +318,7 @@ ${generateFragments(name, primitiveFields, nonPrimitiveFields)}
     const interfaceOrUnionType = interfaceAndUnionTypes.get(type.name)
     const isUnion =
       interfaceOrUnionType && interfaceOrUnionType.kind === "UNION"
+    if (isUnion) unionTypes.push(type.name)
     const fileName = type.name + "ModelSelector"
     const {
       primitiveFields,
@@ -625,6 +627,12 @@ ${objectTypes
       }`
   )
   .join("")}
+${unionTypes.map(
+  t =>
+    `\nimport { ${toFirstLower(t)}ModelPrimitives, ${t}ModelSelector ${ifTS(
+      `, ${t}Union`
+    )} } from "./${t}ModelSelector"`
+)}
 ${enumTypes
   .map(
     t =>

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -632,7 +632,7 @@ ${unionTypes.map(
   t =>
     `\nimport { ${toFirstLower(t)}ModelPrimitives, ${t}ModelSelector ${ifTS(
       `, ${t}Union`
-    )} } from "./${t}ModelSelector"`
+    )} } from "./"`
 )}
 ${enumTypes
   .map(

--- a/tests/generator/__snapshots__/generate.test.js.snap
+++ b/tests/generator/__snapshots__/generate.test.js.snap
@@ -107,6 +107,7 @@ import { UserModel, UserModelType } from \\"./UserModel\\"
 import { userModelPrimitives, UserModelSelector } from \\"./UserModel.base\\"
 
 
+
 /* The TypeScript type that explicits the refs to other models in order to prevent a circular refs issue */
 type Refs = {
   users: ObservableMap<string, UserModelType>
@@ -429,6 +430,7 @@ import { PossiblyEmptyBoxModel, PossiblyEmptyBoxModelType } from \\"./PossiblyEm
 import { possiblyEmptyBoxModelPrimitives, PossiblyEmptyBoxModelSelector } from \\"./PossiblyEmptyBoxModel.base\\"
 
 
+
 /* The TypeScript type that explicits the refs to other models in order to prevent a circular refs issue */
 type Refs = {
   myUsers: ObservableMap<string, MyUserModelType>,
@@ -600,6 +602,7 @@ import { MSTGQLStore, configureStoreMixin, QueryOptions, withTypedRefs } from \\
 
 import { UserModel, UserModelType } from \\"./UserModel\\"
 import { userModelPrimitives, UserModelSelector } from \\"./UserModel.base\\"
+
 
 
 /* The TypeScript type that explicits the refs to other models in order to prevent a circular refs issue */
@@ -839,6 +842,7 @@ import { MSTGQLStore, configureStoreMixin, QueryOptions, withTypedRefs } from \\
 import { UserModel, UserModelType } from \\"./UserModel\\"
 import { userModelPrimitives, UserModelSelector } from \\"./UserModel.base\\"
 
+
 import { Role } from \\"./RoleEnum\\"
 import { interest_enum } from \\"./interest_enum\\"
 
@@ -1075,6 +1079,7 @@ import { MSTGQLStore, configureStoreMixin, QueryOptions, withTypedRefs } from \\
 
 import { UserModel, UserModelType } from \\"./UserModel\\"
 import { userModelPrimitives, UserModelSelector } from \\"./UserModel.base\\"
+
 
 import { Role } from \\"./RoleEnum\\"
 import { InterestEnum } from \\"./InterestEnum\\"
@@ -1414,6 +1419,7 @@ import { OrganizationModel, OrganizationModelType } from \\"./OrganizationModel\
 import { organizationModelPrimitives, OrganizationModelSelector } from \\"./OrganizationModel.base\\"
 
 
+
 /* The TypeScript type that explicits the refs to other models in order to prevent a circular refs issue */
 type Refs = {
   repos: ObservableMap<string, RepoModelType>
@@ -1566,8 +1572,12 @@ export const SearchResultModel = SearchResultModelBase
 /* tslint:disable */
 
 import { QueryBuilder } from \\"mst-gql\\"
+import { BookModelType } from \\"./BookModel\\"
 import { BookModelSelector, bookModelPrimitives } from \\"./BookModel.base\\"
+import { MovieModelType } from \\"./MovieModel\\"
 import { MovieModelSelector, movieModelPrimitives } from \\"./MovieModel.base\\"
+
+export type SearchItemUnion = MovieModelType | BookModelType
 
 export class SearchItemModelSelector extends QueryBuilder {
   movie(builder?: string | MovieModelSelector | ((selector: MovieModelSelector) => MovieModelSelector)) { return this.__inlineFragment(\`Movie\`, MovieModelSelector, builder) }
@@ -1744,6 +1754,8 @@ import { movieModelPrimitives, MovieModelSelector } from \\"./MovieModel.base\\"
 import { BookModel, BookModelType } from \\"./BookModel\\"
 import { bookModelPrimitives, BookModelSelector } from \\"./BookModel.base\\"
 
+import { searchItemModelPrimitives, SearchItemModelSelector , SearchItemUnion } from \\"./\\"
+
 
 /* The TypeScript type that explicits the refs to other models in order to prevent a circular refs issue */
 type Refs = {
@@ -1915,6 +1927,7 @@ import { MSTGQLStore, configureStoreMixin, QueryOptions, withTypedRefs } from \\
 
 import { MovieModel, MovieModelType } from \\"./MovieModel\\"
 import { movieModelPrimitives, MovieModelSelector } from \\"./MovieModel.base\\"
+
 
 
 export type MovieInput = {

--- a/tests/lib/abstractTypes/models/RootStore.base.js
+++ b/tests/lib/abstractTypes/models/RootStore.base.js
@@ -16,6 +16,8 @@ import { userModelPrimitives, UserModelSelector } from "./UserModel.base"
 import { OrganizationModel } from "./OrganizationModel"
 import { organizationModelPrimitives, OrganizationModelSelector } from "./OrganizationModel.base"
 
+import { searchItemModelPrimitives, SearchItemModelSelector  } from "./"
+
 
 
 

--- a/tests/lib/abstractTypes/models/SearchItemModelSelector.js
+++ b/tests/lib/abstractTypes/models/SearchItemModelSelector.js
@@ -2,7 +2,9 @@
 /* eslint-disable */
 
 import { QueryBuilder } from "mst-gql"
+import { BookModelType } from "./BookModel"
 import { BookModelSelector, bookModelPrimitives } from "./BookModel.base"
+import { MovieModelType } from "./MovieModel"
 import { MovieModelSelector, movieModelPrimitives } from "./MovieModel.base"
 
 export class SearchItemModelSelector extends QueryBuilder {

--- a/tests/lib/todos/models/RootStore.base.js
+++ b/tests/lib/todos/models/RootStore.base.js
@@ -11,6 +11,7 @@ import { todoModelPrimitives, TodoModelSelector } from "./TodoModel.base"
 
 
 
+
 /**
 * Store, managing, among others, all the objects received through graphQL
 */


### PR DESCRIPTION
This PR aims to solve https://github.com/mobxjs/mst-gql/issues/255.

- Adds code generation in the `<type>ModelSelector` file for unions (unions don't generate an actual Model or Model.base file and I was following the pattern of putting the extra stuff in this file)
- Adds imports to the `<type>Union` to the `RootStore.base.ts` file for use in actions
- Adds generation to the `queryHelper` function to use the correct type if the action is using a field that is `UNION`

In order to test this out, I added an example `search` field in the twitter example (only server side right now). It uses a union type of User and Message to return results, which creates a new action in the `RootStore.base.ts`. I also tested out the generation in another project (my own) which also generates correct types.