### PR TITLE
Add fieldOverrides to enable the usage of multiple and custom ID types

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ The `mst-gql` command currently accepts the following arguments:
 - `--noReact` doesn't generate the React related utilities
 - `--force` When set, exiting files will always be overridden. This will drop all customizations of model classes!
 - `--dontRenameModels` By default generates model names from graphql schema types that are idiomatic Javascript/Typescript names, ie. type names will be PascalCased and root collection names camelCased. With `--dontRenameModels` the original names - as provided by the graphql schema - will be used for generating models.
+- `--useIdentifierNumber` Specifies the use of `identifierNumber` instead of `identifier` as the mst type for the generated models unique keys. This requires your models to use numbers as their identifiers. See the [mobx-state-tree](https://mobx-state-tree.js.org/overview/types#property-types) for more information.
 - `source` The last argument is the location at which to find the graphQL definitions. This can be
   - a graphql endpoint, like `http://host/graphql`
   - a graphql files, like `schema.graphql`

--- a/README.md
+++ b/README.md
@@ -409,7 +409,21 @@ The `mst-gql` command currently accepts the following arguments:
 - `--noReact` doesn't generate the React related utilities
 - `--force` When set, exiting files will always be overridden. This will drop all customizations of model classes!
 - `--dontRenameModels` By default generates model names from graphql schema types that are idiomatic Javascript/Typescript names, ie. type names will be PascalCased and root collection names camelCased. With `--dontRenameModels` the original names - as provided by the graphql schema - will be used for generating models.
-- `--useIdentifierNumber` Specifies the use of `identifierNumber` instead of `identifier` as the mst type for the generated models unique keys. This requires your models to use numbers as their identifiers. See the [mobx-state-tree](https://mobx-state-tree.js.org/overview/types#property-types) for more information.
+- `--useIdentifierNumber` Specifies the use of `identifierNumber` instead of `identifier` as the mst type for the generated models IDs. This requires your models to use numbers as their identifiers. See the [mobx-state-tree](https://mobx-state-tree.js.org/overview/types#property-types) for more information.
+- `--fieldOverrides id:uuid:idenfitier,*:ID:identifierNumber` Overrides default MST types for matching GraphQL names and types. The format is `gqlFieldName:gqlFieldType:mstType`. Supports full or partial wildcards for fieldNames, and full wildcards for fieldTypes. Case Sensitive. If multiple matches occur, the match with the least amount of wildcards will be used, followd by the order specified in the arg list if there are still multiple matches. Some examples:
+
+  - `*_id:*:string` - Matches any GQL type with the field name `*_id` (like `user_id`), and uses the MST type `types.string`
+  - `*:ID:identifierNumber` - Matches any GQL type with any field name and the `ID` type, and uses the MST type `types.identifierNumber`
+  - `User.user_id:ID:number` - Matches the `user_id` field on `User` with the GQL type `ID`, and uses the MST type `types.number`
+
+    Specifying this argument additionaly allows the use of multiple IDs on a type. The best matched ID will be used, setting the other IDs to `types.frozen()`
+
+  - `Book.author_id:ID:identifierNumber` - Matches the `author_id` field on `Book` with the GQL type `ID` and uses the MST type `types.identifierNumber`, and sets any other GQL IDs on `Book` to `types.frozen()`
+
+    For TS users, input types and query arguments will only be modified for fieldOverrides with a wildcard for `gqlFieldName` (`*:uuid:identifier`). An override like `*_id:uuid:identifier` will not affect input types.
+
+    The primary use case for this feature is for GQL Servers that don't always do what you want. For example, Hasure does not generate GQL ID types for UUID fields, which causes issues when trying to reference associate types in MST. To overcome this, simply specify `--fieldOverrides *:UUID:identifier`
+
 - `source` The last argument is the location at which to find the graphQL definitions. This can be
   - a graphql endpoint, like `http://host/graphql`
   - a graphql files, like `schema.graphql`

--- a/generator/config.js
+++ b/generator/config.js
@@ -14,7 +14,8 @@ exports.defaultConfig = {
   roots: [],
   noReact: false,
   namingConvention: "js", // supported option: "js", "asis",
-  header: undefined
+  header: undefined,
+  useIdentifierNumber: false
 }
 
 exports.getConfig = function getConfig() {
@@ -51,6 +52,8 @@ exports.mergeConfigs = function mergeConfigs(args, config) {
     namingConvention: args["--dontRenameModels"]
       ? "asis"
       : config.namingConvention,
-    header: args["--header"] || headerConfigValues // if multiple headers are passed in config, chain them up to pass on to apollo cli
+    header: args["--header"] || headerConfigValues, // if multiple headers are passed in config, chain them up to pass on to apollo cli
+    useIdentifierNumber:
+      !!args["--useIdentifierNumber"] || config.useIdentifierNumber
   }
 }

--- a/generator/config.js
+++ b/generator/config.js
@@ -15,7 +15,8 @@ exports.defaultConfig = {
   noReact: false,
   namingConvention: "js", // supported option: "js", "asis",
   header: undefined,
-  useIdentifierNumber: false
+  useIdentifierNumber: false,
+  fieldOverrides: []
 }
 
 exports.getConfig = function getConfig() {
@@ -54,6 +55,23 @@ exports.mergeConfigs = function mergeConfigs(args, config) {
       : config.namingConvention,
     header: args["--header"] || headerConfigValues, // if multiple headers are passed in config, chain them up to pass on to apollo cli
     useIdentifierNumber:
-      !!args["--useIdentifierNumber"] || config.useIdentifierNumber
+      !!args["--useIdentifierNumber"] || config.useIdentifierNumber,
+    fieldOverrides: args["--fieldOverrides"]
+      ? parseFieldOverrides(args["--fieldOverrides"])
+      : config.fieldOverrides
   }
+}
+
+const parseFieldOverrides = fieldOverrides => {
+  return fieldOverrides
+    .split(",")
+    .map(s => s.trim())
+    .map(item => {
+      const override = item.split(":").map(s => s.trim())
+
+      if (override.length !== 3)
+        throw new Error("--fieldOverrides used with invalid override: " + item)
+
+      return override
+    })
 }

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -26,7 +26,8 @@ function generate(
   generationDate = "a long long time ago...",
   modelsOnly = false,
   noReact = false,
-  namingConvention = "js"
+  namingConvention = "js",
+  useIdentifierNumber = false
 ) {
   const types = schema.types
 
@@ -400,11 +401,13 @@ ${generateFragments(name, primitiveFields, nonPrimitiveFields)}
       switch (fieldType.kind) {
         case "SCALAR":
           primitiveFields.push(fieldName)
-          const primitiveType = primitiveToMstType(fieldType.name)
-          return result(
-            `types.${primitiveType}`,
-            primitiveType === "identifier"
+          const primitiveType = primitiveToMstType(
+            fieldType.name,
+            useIdentifierNumber
           )
+          const requiredTypes = ["identifier", "identifierNumber"]
+          const isRequired = requiredTypes.includes(primitiveType)
+          return result(`types.${primitiveType}`, isRequired)
         case "OBJECT":
           return result(handleObjectFieldType(fieldName, fieldType, isNested))
         case "LIST":
@@ -901,7 +904,7 @@ ${optPrefix("\n    // ", sanitizeComment(description))}
 
   function printTsPrimitiveType(primitiveType) {
     const res = {
-      ID: "string",
+      ID: useIdentifierNumber ? "number" : "string",
       Int: "number",
       String: "string",
       Float: "number",
@@ -987,9 +990,9 @@ ${toExport.map(f => `export * from "./${f}${importPostFix}"`).join("\n")}
   return files
 }
 
-function primitiveToMstType(type) {
+function primitiveToMstType(type, useIdentifierNumber) {
   const res = {
-    ID: "identifier",
+    ID: useIdentifierNumber ? "identifierNumber" : "identifier",
     Int: "integer",
     String: "string",
     Float: "number",
@@ -1160,7 +1163,8 @@ function scaffold(
     roots: [],
     excludes: [],
     modelsOnly: false,
-    namingConvention: "js"
+    namingConvention: "js",
+    useIdentifierNumber: false
   }
 ) {
   const schema = graphql.buildSchema(definition)
@@ -1175,7 +1179,8 @@ function scaffold(
     "<during unit test run>",
     options.modelsOnly || false,
     options.noReact || false,
-    options.namingConvention || "js"
+    options.namingConvention || "js",
+    options.useIdentifierNumber || false
   )
 }
 

--- a/generator/mst-gql-scaffold.js
+++ b/generator/mst-gql-scaffold.js
@@ -19,7 +19,8 @@ const definition = {
   "--separate": Boolean,
   "--dontRenameModels": Boolean,
   "--header": String,
-  "--useIdentifierNumber": Boolean
+  "--useIdentifierNumber": Boolean,
+  "--fieldOverrides": String
 }
 
 function main() {
@@ -47,7 +48,8 @@ function main() {
     noReact,
     namingConvention,
     header,
-    useIdentifierNumber
+    useIdentifierNumber,
+    fieldOverrides
   } = mergeConfigs(args, config)
   const separate = !!args["--separate"]
 
@@ -111,7 +113,8 @@ function main() {
     modelsOnly,
     noReact,
     namingConvention,
-    useIdentifierNumber
+    useIdentifierNumber,
+    fieldOverrides
   )
   writeFiles(outDir, files, format, forceAll, true, separate)
   logUnexpectedFiles(outDir, files)

--- a/generator/mst-gql-scaffold.js
+++ b/generator/mst-gql-scaffold.js
@@ -18,7 +18,8 @@ const definition = {
   "--noReact": Boolean,
   "--separate": Boolean,
   "--dontRenameModels": Boolean,
-  "--header": String
+  "--header": String,
+  "--useIdentifierNumber": Boolean
 }
 
 function main() {
@@ -45,7 +46,8 @@ function main() {
     forceAll,
     noReact,
     namingConvention,
-    header
+    header,
+    useIdentifierNumber
   } = mergeConfigs(args, config)
   const separate = !!args["--separate"]
 
@@ -108,7 +110,8 @@ function main() {
     new Date().toUTCString(),
     modelsOnly,
     noReact,
-    namingConvention
+    namingConvention,
+    useIdentifierNumber
   )
   writeFiles(outDir, files, format, forceAll, true, separate)
   logUnexpectedFiles(outDir, files)

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -64,3 +64,36 @@ test("config is used for multiple headers", () => {
     "x-hasura-admin-secret:supersecret --header=x-hasura-role:superuser"
   )
 })
+
+test("fieldOverrides outputs items with valid signature", () => {
+  const fieldOverridesArgs = {
+    "--fieldOverrides": "id:uuid:identifier, id:bigint:identifierNumber"
+  }
+  const args = { ...testArgsWithoutHeader, ...fieldOverridesArgs }
+  const config = {
+    input: "http://localhost:8080/v1/graphql",
+    format: "ts",
+    outDir: "src/models",
+    roots: ["todos"]
+  }
+
+  const results = mergeConfigs(args, config)
+
+  expect(results.fieldOverrides).toEqual([
+    ["id", "uuid", "identifier"],
+    ["id", "bigint", "identifierNumber"]
+  ])
+})
+
+test("throws with invalid fieldOverrides format", () => {
+  const fieldOverridesArgs = { "--fieldOverrides": "id:uuid, newId" }
+  const args = { ...testArgsWithoutHeader, ...fieldOverridesArgs }
+  const config = {
+    input: "http://localhost:8080/v1/graphql",
+    format: "ts",
+    outDir: "src/models",
+    roots: ["todos"]
+  }
+
+  expect(() => mergeConfigs(args, config)).toThrow(/invalid override/i)
+})

--- a/tests/generator/__snapshots__/generate.test.js.snap
+++ b/tests/generator/__snapshots__/generate.test.js.snap
@@ -1481,6 +1481,735 @@ export * from \\"./reactUtils\\"
 ]
 `;
 
+exports[`overrides mst type with matching name and gql type using fieldOverrides 1`] = `
+Array [
+  Array [
+    "ModelBase",
+    "import { MSTGQLObject } from \\"mst-gql\\"
+
+export const ModelBase = MSTGQLObject
+",
+    false,
+  ],
+  Array [
+    "UserModel.base",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+import { types } from \\"mobx-state-tree\\"
+import { QueryBuilder } from \\"mst-gql\\"
+import { ModelBase } from \\"./ModelBase\\"
+import { RootStoreType } from \\"./index\\"
+
+
+/**
+ * UserBase
+ * auto generated base class for the model UserModel.
+ */
+export const UserModelBase = ModelBase
+  .named('User')
+  .props({
+    __typename: types.optional(types.literal(\\"User\\"), \\"User\\"),
+    id: types.identifierNumber,
+    name: types.union(types.undefined, types.string),
+  })
+  .views(self => ({
+    get store() {
+      return self.__getStore<RootStoreType>()
+    }
+  }))
+
+export class UserModelSelector extends QueryBuilder {
+  get id() { return this.__attr(\`id\`) }
+  get name() { return this.__attr(\`name\`) }
+}
+export function selectFromUser() {
+  return new UserModelSelector()
+}
+
+export const userModelPrimitives = selectFromUser().name
+",
+    true,
+  ],
+  Array [
+    "UserModel",
+    "import { Instance } from \\"mobx-state-tree\\"
+import { UserModelBase } from \\"./UserModel.base\\"
+
+/* The TypeScript type of an instance of UserModel */
+export interface UserModelType extends Instance<typeof UserModel.Type> {}
+
+/* A graphql query fragment builders for UserModel */
+export { selectFromUser, userModelPrimitives, UserModelSelector } from \\"./UserModel.base\\"
+
+/**
+ * UserModel
+ */
+export const UserModel = UserModelBase
+  .actions(self => ({
+    // This is an auto-generated example action.
+    log() {
+      console.log(JSON.stringify(self))
+    }
+  }))
+",
+    false,
+  ],
+  Array [
+    "BookModel.base",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+import { types } from \\"mobx-state-tree\\"
+import { QueryBuilder } from \\"mst-gql\\"
+import { ModelBase } from \\"./ModelBase\\"
+import { RootStoreType } from \\"./index\\"
+
+
+/**
+ * BookBase
+ * auto generated base class for the model BookModel.
+ */
+export const BookModelBase = ModelBase
+  .named('Book')
+  .props({
+    __typename: types.optional(types.literal(\\"Book\\"), \\"Book\\"),
+    id: types.identifier,
+    name: types.union(types.undefined, types.string),
+  })
+  .views(self => ({
+    get store() {
+      return self.__getStore<RootStoreType>()
+    }
+  }))
+
+export class BookModelSelector extends QueryBuilder {
+  get id() { return this.__attr(\`id\`) }
+  get name() { return this.__attr(\`name\`) }
+}
+export function selectFromBook() {
+  return new BookModelSelector()
+}
+
+export const bookModelPrimitives = selectFromBook().name
+",
+    true,
+  ],
+  Array [
+    "BookModel",
+    "import { Instance } from \\"mobx-state-tree\\"
+import { BookModelBase } from \\"./BookModel.base\\"
+
+/* The TypeScript type of an instance of BookModel */
+export interface BookModelType extends Instance<typeof BookModel.Type> {}
+
+/* A graphql query fragment builders for BookModel */
+export { selectFromBook, bookModelPrimitives, BookModelSelector } from \\"./BookModel.base\\"
+
+/**
+ * BookModel
+ */
+export const BookModel = BookModelBase
+  .actions(self => ({
+    // This is an auto-generated example action.
+    log() {
+      console.log(JSON.stringify(self))
+    }
+  }))
+",
+    false,
+  ],
+  Array [
+    "RootStore",
+    "import { Instance } from \\"mobx-state-tree\\"
+import { RootStoreBase } from \\"./RootStore.base\\"
+
+export interface RootStoreType extends Instance<typeof RootStore.Type> {}
+
+export const RootStore = RootStoreBase
+  .actions(self => ({
+    // This is an auto-generated example action.
+    log() {
+      console.log(JSON.stringify(self))
+    }
+  }))
+",
+    false,
+  ],
+  Array [
+    "RootStore.base",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+import { ObservableMap } from \\"mobx\\"
+import { types } from \\"mobx-state-tree\\"
+import { MSTGQLStore, configureStoreMixin, QueryOptions, withTypedRefs } from \\"mst-gql\\"
+
+import { UserModel, UserModelType } from \\"./UserModel\\"
+import { userModelPrimitives, UserModelSelector } from \\"./UserModel.base\\"
+import { BookModel, BookModelType } from \\"./BookModel\\"
+import { bookModelPrimitives, BookModelSelector } from \\"./BookModel.base\\"
+
+
+/* The TypeScript type that explicits the refs to other models in order to prevent a circular refs issue */
+type Refs = {
+  users: ObservableMap<string, UserModelType>
+}
+
+
+/**
+* Enums for the names of base graphql actions
+*/
+export enum RootStoreBaseQueries {
+queryMe=\\"queryMe\\",
+queryBook=\\"queryBook\\"
+}
+
+
+/**
+* Store, managing, among others, all the objects received through graphQL
+*/
+export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
+  .named(\\"RootStore\\")
+  .extend(configureStoreMixin([['User', () => UserModel], ['Book', () => BookModel]], ['User'], \\"js\\"))
+  .props({
+    users: types.optional(types.map(types.late((): any => UserModel)), {})
+  })
+  .actions(self => ({
+    queryMe(variables?: {  }, resultSelector: string | ((qb: UserModelSelector) => UserModelSelector) = userModelPrimitives.toString(), options: QueryOptions = {}) {
+      return self.query<{ me: UserModelType}>(\`query me { me {
+        \${typeof resultSelector === \\"function\\" ? resultSelector(new UserModelSelector()).toString() : resultSelector}
+      } }\`, variables, options)
+    },
+    queryBook(variables?: {  }, resultSelector: string | ((qb: BookModelSelector) => BookModelSelector) = bookModelPrimitives.toString(), options: QueryOptions = {}) {
+      return self.query<{ book: BookModelType}>(\`query book { book {
+        \${typeof resultSelector === \\"function\\" ? resultSelector(new BookModelSelector()).toString() : resultSelector}
+      } }\`, variables, options)
+    },
+  })))
+",
+    true,
+  ],
+  Array [
+    "reactUtils",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+import { createStoreContext, createUseQueryHook } from \\"mst-gql\\"
+import * as React from \\"react\\"
+import { RootStoreType } from \\"./RootStore\\"
+
+export const StoreContext = createStoreContext<RootStoreType>(React)
+
+export const useQuery = createUseQueryHook(StoreContext, React)
+",
+    true,
+  ],
+  Array [
+    "index",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+export * from \\"./UserModel\\"
+export * from \\"./BookModel\\"
+export * from \\"./RootStore\\"
+export * from \\"./reactUtils\\"
+",
+    true,
+  ],
+]
+`;
+
+exports[`overrides mst type with partial wildcard name using fieldOverrides 1`] = `
+Array [
+  Array [
+    "ModelBase",
+    "import { MSTGQLObject } from \\"mst-gql\\"
+
+export const ModelBase = MSTGQLObject
+",
+    false,
+  ],
+  Array [
+    "UserModel.base",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+import { types } from \\"mobx-state-tree\\"
+import { QueryBuilder } from \\"mst-gql\\"
+import { ModelBase } from \\"./ModelBase\\"
+import { RootStoreType } from \\"./index\\"
+
+
+/**
+ * UserBase
+ * auto generated base class for the model UserModel.
+ */
+export const UserModelBase = ModelBase
+  .named('User')
+  .props({
+    __typename: types.optional(types.literal(\\"User\\"), \\"User\\"),
+    user_id: types.identifier,
+    name: types.union(types.undefined, types.string),
+  })
+  .views(self => ({
+    get store() {
+      return self.__getStore<RootStoreType>()
+    }
+  }))
+
+export class UserModelSelector extends QueryBuilder {
+  get user_id() { return this.__attr(\`user_id\`) }
+  get name() { return this.__attr(\`name\`) }
+}
+export function selectFromUser() {
+  return new UserModelSelector()
+}
+
+export const userModelPrimitives = selectFromUser().user_id.name
+",
+    true,
+  ],
+  Array [
+    "UserModel",
+    "import { Instance } from \\"mobx-state-tree\\"
+import { UserModelBase } from \\"./UserModel.base\\"
+
+/* The TypeScript type of an instance of UserModel */
+export interface UserModelType extends Instance<typeof UserModel.Type> {}
+
+/* A graphql query fragment builders for UserModel */
+export { selectFromUser, userModelPrimitives, UserModelSelector } from \\"./UserModel.base\\"
+
+/**
+ * UserModel
+ */
+export const UserModel = UserModelBase
+  .actions(self => ({
+    // This is an auto-generated example action.
+    log() {
+      console.log(JSON.stringify(self))
+    }
+  }))
+",
+    false,
+  ],
+  Array [
+    "BookModel.base",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+import { types } from \\"mobx-state-tree\\"
+import { QueryBuilder } from \\"mst-gql\\"
+import { ModelBase } from \\"./ModelBase\\"
+import { RootStoreType } from \\"./index\\"
+
+
+/**
+ * BookBase
+ * auto generated base class for the model BookModel.
+ */
+export const BookModelBase = ModelBase
+  .named('Book')
+  .props({
+    __typename: types.optional(types.literal(\\"Book\\"), \\"Book\\"),
+    id: types.union(types.undefined, types.frozen()),
+    name: types.union(types.undefined, types.string),
+  })
+  .views(self => ({
+    get store() {
+      return self.__getStore<RootStoreType>()
+    }
+  }))
+
+export class BookModelSelector extends QueryBuilder {
+  get id() { return this.__attr(\`id\`) }
+  get name() { return this.__attr(\`name\`) }
+}
+export function selectFromBook() {
+  return new BookModelSelector()
+}
+
+export const bookModelPrimitives = selectFromBook().name
+",
+    true,
+  ],
+  Array [
+    "BookModel",
+    "import { Instance } from \\"mobx-state-tree\\"
+import { BookModelBase } from \\"./BookModel.base\\"
+
+/* The TypeScript type of an instance of BookModel */
+export interface BookModelType extends Instance<typeof BookModel.Type> {}
+
+/* A graphql query fragment builders for BookModel */
+export { selectFromBook, bookModelPrimitives, BookModelSelector } from \\"./BookModel.base\\"
+
+/**
+ * BookModel
+ */
+export const BookModel = BookModelBase
+  .actions(self => ({
+    // This is an auto-generated example action.
+    log() {
+      console.log(JSON.stringify(self))
+    }
+  }))
+",
+    false,
+  ],
+  Array [
+    "RootStore",
+    "import { Instance } from \\"mobx-state-tree\\"
+import { RootStoreBase } from \\"./RootStore.base\\"
+
+export interface RootStoreType extends Instance<typeof RootStore.Type> {}
+
+export const RootStore = RootStoreBase
+  .actions(self => ({
+    // This is an auto-generated example action.
+    log() {
+      console.log(JSON.stringify(self))
+    }
+  }))
+",
+    false,
+  ],
+  Array [
+    "RootStore.base",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+import { ObservableMap } from \\"mobx\\"
+import { types } from \\"mobx-state-tree\\"
+import { MSTGQLStore, configureStoreMixin, QueryOptions, withTypedRefs } from \\"mst-gql\\"
+
+import { UserModel, UserModelType } from \\"./UserModel\\"
+import { userModelPrimitives, UserModelSelector } from \\"./UserModel.base\\"
+import { BookModel, BookModelType } from \\"./BookModel\\"
+import { bookModelPrimitives, BookModelSelector } from \\"./BookModel.base\\"
+
+
+/* The TypeScript type that explicits the refs to other models in order to prevent a circular refs issue */
+type Refs = {
+  users: ObservableMap<string, UserModelType>
+}
+
+
+/**
+* Enums for the names of base graphql actions
+*/
+export enum RootStoreBaseQueries {
+queryMe=\\"queryMe\\",
+queryBook=\\"queryBook\\"
+}
+
+
+/**
+* Store, managing, among others, all the objects received through graphQL
+*/
+export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
+  .named(\\"RootStore\\")
+  .extend(configureStoreMixin([['User', () => UserModel], ['Book', () => BookModel]], ['User'], \\"js\\"))
+  .props({
+    users: types.optional(types.map(types.late((): any => UserModel)), {})
+  })
+  .actions(self => ({
+    queryMe(variables?: {  }, resultSelector: string | ((qb: UserModelSelector) => UserModelSelector) = userModelPrimitives.toString(), options: QueryOptions = {}) {
+      return self.query<{ me: UserModelType}>(\`query me { me {
+        \${typeof resultSelector === \\"function\\" ? resultSelector(new UserModelSelector()).toString() : resultSelector}
+      } }\`, variables, options)
+    },
+    queryBook(variables?: {  }, resultSelector: string | ((qb: BookModelSelector) => BookModelSelector) = bookModelPrimitives.toString(), options: QueryOptions = {}) {
+      return self.query<{ book: BookModelType}>(\`query book { book {
+        \${typeof resultSelector === \\"function\\" ? resultSelector(new BookModelSelector()).toString() : resultSelector}
+      } }\`, variables, options)
+    },
+  })))
+",
+    true,
+  ],
+  Array [
+    "reactUtils",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+import { createStoreContext, createUseQueryHook } from \\"mst-gql\\"
+import * as React from \\"react\\"
+import { RootStoreType } from \\"./RootStore\\"
+
+export const StoreContext = createStoreContext<RootStoreType>(React)
+
+export const useQuery = createUseQueryHook(StoreContext, React)
+",
+    true,
+  ],
+  Array [
+    "index",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+export * from \\"./UserModel\\"
+export * from \\"./BookModel\\"
+export * from \\"./RootStore\\"
+export * from \\"./reactUtils\\"
+",
+    true,
+  ],
+]
+`;
+
+exports[`overrides mst type with wildcard name or wildcard type using fieldOverrides 1`] = `
+Array [
+  Array [
+    "ModelBase",
+    "import { MSTGQLObject } from \\"mst-gql\\"
+
+export const ModelBase = MSTGQLObject
+",
+    false,
+  ],
+  Array [
+    "UserModel.base",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+import { types } from \\"mobx-state-tree\\"
+import { QueryBuilder } from \\"mst-gql\\"
+import { ModelBase } from \\"./ModelBase\\"
+import { RootStoreType } from \\"./index\\"
+
+
+/**
+ * UserBase
+ * auto generated base class for the model UserModel.
+ */
+export const UserModelBase = ModelBase
+  .named('User')
+  .props({
+    __typename: types.optional(types.literal(\\"User\\"), \\"User\\"),
+    id: types.identifierNumber,
+    name: types.union(types.undefined, types.string),
+  })
+  .views(self => ({
+    get store() {
+      return self.__getStore<RootStoreType>()
+    }
+  }))
+
+export class UserModelSelector extends QueryBuilder {
+  get id() { return this.__attr(\`id\`) }
+  get name() { return this.__attr(\`name\`) }
+}
+export function selectFromUser() {
+  return new UserModelSelector()
+}
+
+export const userModelPrimitives = selectFromUser().name
+",
+    true,
+  ],
+  Array [
+    "UserModel",
+    "import { Instance } from \\"mobx-state-tree\\"
+import { UserModelBase } from \\"./UserModel.base\\"
+
+/* The TypeScript type of an instance of UserModel */
+export interface UserModelType extends Instance<typeof UserModel.Type> {}
+
+/* A graphql query fragment builders for UserModel */
+export { selectFromUser, userModelPrimitives, UserModelSelector } from \\"./UserModel.base\\"
+
+/**
+ * UserModel
+ */
+export const UserModel = UserModelBase
+  .actions(self => ({
+    // This is an auto-generated example action.
+    log() {
+      console.log(JSON.stringify(self))
+    }
+  }))
+",
+    false,
+  ],
+  Array [
+    "BookModel.base",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+import { types } from \\"mobx-state-tree\\"
+import { QueryBuilder } from \\"mst-gql\\"
+import { ModelBase } from \\"./ModelBase\\"
+import { RootStoreType } from \\"./index\\"
+
+
+/**
+ * BookBase
+ * auto generated base class for the model BookModel.
+ */
+export const BookModelBase = ModelBase
+  .named('Book')
+  .props({
+    __typename: types.optional(types.literal(\\"Book\\"), \\"Book\\"),
+    id: types.identifier,
+    name: types.union(types.undefined, types.string),
+  })
+  .views(self => ({
+    get store() {
+      return self.__getStore<RootStoreType>()
+    }
+  }))
+
+export class BookModelSelector extends QueryBuilder {
+  get id() { return this.__attr(\`id\`) }
+  get name() { return this.__attr(\`name\`) }
+}
+export function selectFromBook() {
+  return new BookModelSelector()
+}
+
+export const bookModelPrimitives = selectFromBook().name
+",
+    true,
+  ],
+  Array [
+    "BookModel",
+    "import { Instance } from \\"mobx-state-tree\\"
+import { BookModelBase } from \\"./BookModel.base\\"
+
+/* The TypeScript type of an instance of BookModel */
+export interface BookModelType extends Instance<typeof BookModel.Type> {}
+
+/* A graphql query fragment builders for BookModel */
+export { selectFromBook, bookModelPrimitives, BookModelSelector } from \\"./BookModel.base\\"
+
+/**
+ * BookModel
+ */
+export const BookModel = BookModelBase
+  .actions(self => ({
+    // This is an auto-generated example action.
+    log() {
+      console.log(JSON.stringify(self))
+    }
+  }))
+",
+    false,
+  ],
+  Array [
+    "RootStore",
+    "import { Instance } from \\"mobx-state-tree\\"
+import { RootStoreBase } from \\"./RootStore.base\\"
+
+export interface RootStoreType extends Instance<typeof RootStore.Type> {}
+
+export const RootStore = RootStoreBase
+  .actions(self => ({
+    // This is an auto-generated example action.
+    log() {
+      console.log(JSON.stringify(self))
+    }
+  }))
+",
+    false,
+  ],
+  Array [
+    "RootStore.base",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+import { ObservableMap } from \\"mobx\\"
+import { types } from \\"mobx-state-tree\\"
+import { MSTGQLStore, configureStoreMixin, QueryOptions, withTypedRefs } from \\"mst-gql\\"
+
+import { UserModel, UserModelType } from \\"./UserModel\\"
+import { userModelPrimitives, UserModelSelector } from \\"./UserModel.base\\"
+import { BookModel, BookModelType } from \\"./BookModel\\"
+import { bookModelPrimitives, BookModelSelector } from \\"./BookModel.base\\"
+
+
+/* The TypeScript type that explicits the refs to other models in order to prevent a circular refs issue */
+type Refs = {
+  users: ObservableMap<string, UserModelType>
+}
+
+
+/**
+* Enums for the names of base graphql actions
+*/
+export enum RootStoreBaseQueries {
+queryMe=\\"queryMe\\",
+queryBook=\\"queryBook\\"
+}
+
+
+/**
+* Store, managing, among others, all the objects received through graphQL
+*/
+export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
+  .named(\\"RootStore\\")
+  .extend(configureStoreMixin([['User', () => UserModel], ['Book', () => BookModel]], ['User'], \\"js\\"))
+  .props({
+    users: types.optional(types.map(types.late((): any => UserModel)), {})
+  })
+  .actions(self => ({
+    queryMe(variables?: {  }, resultSelector: string | ((qb: UserModelSelector) => UserModelSelector) = userModelPrimitives.toString(), options: QueryOptions = {}) {
+      return self.query<{ me: UserModelType}>(\`query me { me {
+        \${typeof resultSelector === \\"function\\" ? resultSelector(new UserModelSelector()).toString() : resultSelector}
+      } }\`, variables, options)
+    },
+    queryBook(variables?: {  }, resultSelector: string | ((qb: BookModelSelector) => BookModelSelector) = bookModelPrimitives.toString(), options: QueryOptions = {}) {
+      return self.query<{ book: BookModelType}>(\`query book { book {
+        \${typeof resultSelector === \\"function\\" ? resultSelector(new BookModelSelector()).toString() : resultSelector}
+      } }\`, variables, options)
+    },
+  })))
+",
+    true,
+  ],
+  Array [
+    "reactUtils",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+import { createStoreContext, createUseQueryHook } from \\"mst-gql\\"
+import * as React from \\"react\\"
+import { RootStoreType } from \\"./RootStore\\"
+
+export const StoreContext = createStoreContext<RootStoreType>(React)
+
+export const useQuery = createUseQueryHook(StoreContext, React)
+",
+    true,
+  ],
+  Array [
+    "index",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+export * from \\"./UserModel\\"
+export * from \\"./BookModel\\"
+export * from \\"./RootStore\\"
+export * from \\"./reactUtils\\"
+",
+    true,
+  ],
+]
+`;
+
 exports[`union field type to work 1`] = `
 Array [
   Array [

--- a/tests/generator/__snapshots__/generate.test.js.snap
+++ b/tests/generator/__snapshots__/generate.test.js.snap
@@ -1812,6 +1812,186 @@ export * from \\"./reactUtils\\"
 ]
 `;
 
+exports[`use identifierNumber as ID with useIdentifierNumber=true 1`] = `
+Array [
+  Array [
+    "ModelBase",
+    "import { MSTGQLObject } from \\"mst-gql\\"
+
+export const ModelBase = MSTGQLObject
+",
+    false,
+  ],
+  Array [
+    "UserModel.base",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+import { types } from \\"mobx-state-tree\\"
+import { QueryBuilder } from \\"mst-gql\\"
+import { ModelBase } from \\"./ModelBase\\"
+import { RootStoreType } from \\"./index\\"
+
+
+/**
+ * UserBase
+ * auto generated base class for the model UserModel.
+ */
+export const UserModelBase = ModelBase
+  .named('User')
+  .props({
+    __typename: types.optional(types.literal(\\"User\\"), \\"User\\"),
+    id: types.identifierNumber,
+    name: types.union(types.undefined, types.string),
+    avatar: types.union(types.undefined, types.string),
+  })
+  .views(self => ({
+    get store() {
+      return self.__getStore<RootStoreType>()
+    }
+  }))
+
+export class UserModelSelector extends QueryBuilder {
+  get id() { return this.__attr(\`id\`) }
+  get name() { return this.__attr(\`name\`) }
+  get avatar() { return this.__attr(\`avatar\`) }
+}
+export function selectFromUser() {
+  return new UserModelSelector()
+}
+
+export const userModelPrimitives = selectFromUser().name.avatar
+",
+    true,
+  ],
+  Array [
+    "UserModel",
+    "import { Instance } from \\"mobx-state-tree\\"
+import { UserModelBase } from \\"./UserModel.base\\"
+
+/* The TypeScript type of an instance of UserModel */
+export interface UserModelType extends Instance<typeof UserModel.Type> {}
+
+/* A graphql query fragment builders for UserModel */
+export { selectFromUser, userModelPrimitives, UserModelSelector } from \\"./UserModel.base\\"
+
+/**
+ * UserModel
+ */
+export const UserModel = UserModelBase
+  .actions(self => ({
+    // This is an auto-generated example action.
+    log() {
+      console.log(JSON.stringify(self))
+    }
+  }))
+",
+    false,
+  ],
+  Array [
+    "RootStore",
+    "import { Instance } from \\"mobx-state-tree\\"
+import { RootStoreBase } from \\"./RootStore.base\\"
+
+export interface RootStoreType extends Instance<typeof RootStore.Type> {}
+
+export const RootStore = RootStoreBase
+  .actions(self => ({
+    // This is an auto-generated example action.
+    log() {
+      console.log(JSON.stringify(self))
+    }
+  }))
+",
+    false,
+  ],
+  Array [
+    "RootStore.base",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+import { ObservableMap } from \\"mobx\\"
+import { types } from \\"mobx-state-tree\\"
+import { MSTGQLStore, configureStoreMixin, QueryOptions, withTypedRefs } from \\"mst-gql\\"
+
+import { UserModel, UserModelType } from \\"./UserModel\\"
+import { userModelPrimitives, UserModelSelector } from \\"./UserModel.base\\"
+
+
+export type UsersFilter = {
+  ids: number[]
+}
+/* The TypeScript type that explicits the refs to other models in order to prevent a circular refs issue */
+type Refs = {
+  users: ObservableMap<string, UserModelType>
+}
+
+
+/**
+* Enums for the names of base graphql actions
+*/
+export enum RootStoreBaseQueries {
+queryUser=\\"queryUser\\",
+queryUsers=\\"queryUsers\\"
+}
+
+
+/**
+* Store, managing, among others, all the objects received through graphQL
+*/
+export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
+  .named(\\"RootStore\\")
+  .extend(configureStoreMixin([['User', () => UserModel]], ['User'], \\"js\\"))
+  .props({
+    users: types.optional(types.map(types.late((): any => UserModel)), {})
+  })
+  .actions(self => ({
+    queryUser(variables: { id: number }, resultSelector: string | ((qb: UserModelSelector) => UserModelSelector) = userModelPrimitives.toString(), options: QueryOptions = {}) {
+      return self.query<{ user: UserModelType}>(\`query user($id: ID!) { user(id: $id) {
+        \${typeof resultSelector === \\"function\\" ? resultSelector(new UserModelSelector()).toString() : resultSelector}
+      } }\`, variables, options)
+    },
+    queryUsers(variables: { input: UsersFilter }, resultSelector: string | ((qb: UserModelSelector) => UserModelSelector) = userModelPrimitives.toString(), options: QueryOptions = {}) {
+      return self.query<{ users: UserModelType[]}>(\`query users($input: UsersFilter!) { users(input: $input) {
+        \${typeof resultSelector === \\"function\\" ? resultSelector(new UserModelSelector()).toString() : resultSelector}
+      } }\`, variables, options)
+    },
+  })))
+",
+    true,
+  ],
+  Array [
+    "reactUtils",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+import { createStoreContext, createUseQueryHook } from \\"mst-gql\\"
+import * as React from \\"react\\"
+import { RootStoreType } from \\"./RootStore\\"
+
+export const StoreContext = createStoreContext<RootStoreType>(React)
+
+export const useQuery = createUseQueryHook(StoreContext, React)
+",
+    true,
+  ],
+  Array [
+    "index",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+export * from \\"./UserModel\\"
+export * from \\"./RootStore\\"
+export * from \\"./reactUtils\\"
+",
+    true,
+  ],
+]
+`;
+
 exports[`when array is not required, should be optional in TS 1`] = `
 Array [
   Array [

--- a/tests/generator/__snapshots__/generate.test.js.snap
+++ b/tests/generator/__snapshots__/generate.test.js.snap
@@ -1481,6 +1481,178 @@ export * from \\"./reactUtils\\"
 ]
 `;
 
+exports[`overrides TS types for query arguments and input types for fields with global type overrides with fieldOverrides 1`] = `
+Array [
+  Array [
+    "ModelBase",
+    "import { MSTGQLObject } from \\"mst-gql\\"
+
+export const ModelBase = MSTGQLObject
+",
+    false,
+  ],
+  Array [
+    "UserModel.base",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+import { types } from \\"mobx-state-tree\\"
+import { QueryBuilder } from \\"mst-gql\\"
+import { ModelBase } from \\"./ModelBase\\"
+import { RootStoreType } from \\"./index\\"
+
+
+/**
+ * UserBase
+ * auto generated base class for the model UserModel.
+ */
+export const UserModelBase = ModelBase
+  .named('User')
+  .props({
+    __typename: types.optional(types.literal(\\"User\\"), \\"User\\"),
+    id: types.identifier,
+    name: types.union(types.undefined, types.string),
+  })
+  .views(self => ({
+    get store() {
+      return self.__getStore<RootStoreType>()
+    }
+  }))
+
+export class UserModelSelector extends QueryBuilder {
+  get id() { return this.__attr(\`id\`) }
+  get name() { return this.__attr(\`name\`) }
+}
+export function selectFromUser() {
+  return new UserModelSelector()
+}
+
+export const userModelPrimitives = selectFromUser().name
+",
+    true,
+  ],
+  Array [
+    "UserModel",
+    "import { Instance } from \\"mobx-state-tree\\"
+import { UserModelBase } from \\"./UserModel.base\\"
+
+/* The TypeScript type of an instance of UserModel */
+export interface UserModelType extends Instance<typeof UserModel.Type> {}
+
+/* A graphql query fragment builders for UserModel */
+export { selectFromUser, userModelPrimitives, UserModelSelector } from \\"./UserModel.base\\"
+
+/**
+ * UserModel
+ */
+export const UserModel = UserModelBase
+  .actions(self => ({
+    // This is an auto-generated example action.
+    log() {
+      console.log(JSON.stringify(self))
+    }
+  }))
+",
+    false,
+  ],
+  Array [
+    "RootStore",
+    "import { Instance } from \\"mobx-state-tree\\"
+import { RootStoreBase } from \\"./RootStore.base\\"
+
+export interface RootStoreType extends Instance<typeof RootStore.Type> {}
+
+export const RootStore = RootStoreBase
+  .actions(self => ({
+    // This is an auto-generated example action.
+    log() {
+      console.log(JSON.stringify(self))
+    }
+  }))
+",
+    false,
+  ],
+  Array [
+    "RootStore.base",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+import { ObservableMap } from \\"mobx\\"
+import { types } from \\"mobx-state-tree\\"
+import { MSTGQLStore, configureStoreMixin, QueryOptions, withTypedRefs } from \\"mst-gql\\"
+
+import { UserModel, UserModelType } from \\"./UserModel\\"
+import { userModelPrimitives, UserModelSelector } from \\"./UserModel.base\\"
+
+
+export type UserInput = {
+  user_id: string
+}
+/* The TypeScript type that explicits the refs to other models in order to prevent a circular refs issue */
+type Refs = {
+  users: ObservableMap<string, UserModelType>
+}
+
+
+/**
+* Enums for the names of base graphql actions
+*/
+export enum RootStoreBaseQueries {
+queryGetUser=\\"queryGetUser\\"
+}
+
+
+/**
+* Store, managing, among others, all the objects received through graphQL
+*/
+export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
+  .named(\\"RootStore\\")
+  .extend(configureStoreMixin([['User', () => UserModel]], ['User'], \\"js\\"))
+  .props({
+    users: types.optional(types.map(types.late((): any => UserModel)), {})
+  })
+  .actions(self => ({
+    queryGetUser(variables: { input?: UserInput }, resultSelector: string | ((qb: UserModelSelector) => UserModelSelector) = userModelPrimitives.toString(), options: QueryOptions = {}) {
+      return self.query<{ getUser: UserModelType}>(\`query getUser($input: UserInput) { getUser(input: $input) {
+        \${typeof resultSelector === \\"function\\" ? resultSelector(new UserModelSelector()).toString() : resultSelector}
+      } }\`, variables, options)
+    },
+  })))
+",
+    true,
+  ],
+  Array [
+    "reactUtils",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+import { createStoreContext, createUseQueryHook } from \\"mst-gql\\"
+import * as React from \\"react\\"
+import { RootStoreType } from \\"./RootStore\\"
+
+export const StoreContext = createStoreContext<RootStoreType>(React)
+
+export const useQuery = createUseQueryHook(StoreContext, React)
+",
+    true,
+  ],
+  Array [
+    "index",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+export * from \\"./UserModel\\"
+export * from \\"./RootStore\\"
+export * from \\"./reactUtils\\"
+",
+    true,
+  ],
+]
+`;
+
 exports[`overrides mst type with matching name and gql type using fieldOverrides 1`] = `
 Array [
   Array [

--- a/tests/generator/__snapshots__/generate.test.js.snap
+++ b/tests/generator/__snapshots__/generate.test.js.snap
@@ -2210,6 +2210,249 @@ export * from \\"./reactUtils\\"
 ]
 `;
 
+exports[`overrides with multiple matches uses best one when using fieldOverrides 1`] = `
+Array [
+  Array [
+    "ModelBase",
+    "import { MSTGQLObject } from \\"mst-gql\\"
+
+export const ModelBase = MSTGQLObject
+",
+    false,
+  ],
+  Array [
+    "UserModel.base",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+import { types } from \\"mobx-state-tree\\"
+import { QueryBuilder } from \\"mst-gql\\"
+import { ModelBase } from \\"./ModelBase\\"
+import { RootStoreType } from \\"./index\\"
+
+
+/**
+ * UserBase
+ * auto generated base class for the model UserModel.
+ */
+export const UserModelBase = ModelBase
+  .named('User')
+  .props({
+    __typename: types.optional(types.literal(\\"User\\"), \\"User\\"),
+    id: types.identifierNumber,
+    name: types.union(types.undefined, types.string),
+  })
+  .views(self => ({
+    get store() {
+      return self.__getStore<RootStoreType>()
+    }
+  }))
+
+export class UserModelSelector extends QueryBuilder {
+  get id() { return this.__attr(\`id\`) }
+  get name() { return this.__attr(\`name\`) }
+}
+export function selectFromUser() {
+  return new UserModelSelector()
+}
+
+export const userModelPrimitives = selectFromUser().name
+",
+    true,
+  ],
+  Array [
+    "UserModel",
+    "import { Instance } from \\"mobx-state-tree\\"
+import { UserModelBase } from \\"./UserModel.base\\"
+
+/* The TypeScript type of an instance of UserModel */
+export interface UserModelType extends Instance<typeof UserModel.Type> {}
+
+/* A graphql query fragment builders for UserModel */
+export { selectFromUser, userModelPrimitives, UserModelSelector } from \\"./UserModel.base\\"
+
+/**
+ * UserModel
+ */
+export const UserModel = UserModelBase
+  .actions(self => ({
+    // This is an auto-generated example action.
+    log() {
+      console.log(JSON.stringify(self))
+    }
+  }))
+",
+    false,
+  ],
+  Array [
+    "BookModel.base",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+import { types } from \\"mobx-state-tree\\"
+import { QueryBuilder } from \\"mst-gql\\"
+import { ModelBase } from \\"./ModelBase\\"
+import { RootStoreType } from \\"./index\\"
+
+
+/**
+ * BookBase
+ * auto generated base class for the model BookModel.
+ */
+export const BookModelBase = ModelBase
+  .named('Book')
+  .props({
+    __typename: types.optional(types.literal(\\"Book\\"), \\"Book\\"),
+    id: types.identifierNumber,
+    name: types.union(types.undefined, types.string),
+  })
+  .views(self => ({
+    get store() {
+      return self.__getStore<RootStoreType>()
+    }
+  }))
+
+export class BookModelSelector extends QueryBuilder {
+  get id() { return this.__attr(\`id\`) }
+  get name() { return this.__attr(\`name\`) }
+}
+export function selectFromBook() {
+  return new BookModelSelector()
+}
+
+export const bookModelPrimitives = selectFromBook().name
+",
+    true,
+  ],
+  Array [
+    "BookModel",
+    "import { Instance } from \\"mobx-state-tree\\"
+import { BookModelBase } from \\"./BookModel.base\\"
+
+/* The TypeScript type of an instance of BookModel */
+export interface BookModelType extends Instance<typeof BookModel.Type> {}
+
+/* A graphql query fragment builders for BookModel */
+export { selectFromBook, bookModelPrimitives, BookModelSelector } from \\"./BookModel.base\\"
+
+/**
+ * BookModel
+ */
+export const BookModel = BookModelBase
+  .actions(self => ({
+    // This is an auto-generated example action.
+    log() {
+      console.log(JSON.stringify(self))
+    }
+  }))
+",
+    false,
+  ],
+  Array [
+    "RootStore",
+    "import { Instance } from \\"mobx-state-tree\\"
+import { RootStoreBase } from \\"./RootStore.base\\"
+
+export interface RootStoreType extends Instance<typeof RootStore.Type> {}
+
+export const RootStore = RootStoreBase
+  .actions(self => ({
+    // This is an auto-generated example action.
+    log() {
+      console.log(JSON.stringify(self))
+    }
+  }))
+",
+    false,
+  ],
+  Array [
+    "RootStore.base",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+import { ObservableMap } from \\"mobx\\"
+import { types } from \\"mobx-state-tree\\"
+import { MSTGQLStore, configureStoreMixin, QueryOptions, withTypedRefs } from \\"mst-gql\\"
+
+import { UserModel, UserModelType } from \\"./UserModel\\"
+import { userModelPrimitives, UserModelSelector } from \\"./UserModel.base\\"
+import { BookModel, BookModelType } from \\"./BookModel\\"
+import { bookModelPrimitives, BookModelSelector } from \\"./BookModel.base\\"
+
+
+/* The TypeScript type that explicits the refs to other models in order to prevent a circular refs issue */
+type Refs = {
+  users: ObservableMap<string, UserModelType>
+}
+
+
+/**
+* Enums for the names of base graphql actions
+*/
+export enum RootStoreBaseQueries {
+queryMe=\\"queryMe\\",
+queryBook=\\"queryBook\\"
+}
+
+
+/**
+* Store, managing, among others, all the objects received through graphQL
+*/
+export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
+  .named(\\"RootStore\\")
+  .extend(configureStoreMixin([['User', () => UserModel], ['Book', () => BookModel]], ['User'], \\"js\\"))
+  .props({
+    users: types.optional(types.map(types.late((): any => UserModel)), {})
+  })
+  .actions(self => ({
+    queryMe(variables?: {  }, resultSelector: string | ((qb: UserModelSelector) => UserModelSelector) = userModelPrimitives.toString(), options: QueryOptions = {}) {
+      return self.query<{ me: UserModelType}>(\`query me { me {
+        \${typeof resultSelector === \\"function\\" ? resultSelector(new UserModelSelector()).toString() : resultSelector}
+      } }\`, variables, options)
+    },
+    queryBook(variables?: {  }, resultSelector: string | ((qb: BookModelSelector) => BookModelSelector) = bookModelPrimitives.toString(), options: QueryOptions = {}) {
+      return self.query<{ book: BookModelType}>(\`query book { book {
+        \${typeof resultSelector === \\"function\\" ? resultSelector(new BookModelSelector()).toString() : resultSelector}
+      } }\`, variables, options)
+    },
+  })))
+",
+    true,
+  ],
+  Array [
+    "reactUtils",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+import { createStoreContext, createUseQueryHook } from \\"mst-gql\\"
+import * as React from \\"react\\"
+import { RootStoreType } from \\"./RootStore\\"
+
+export const StoreContext = createStoreContext<RootStoreType>(React)
+
+export const useQuery = createUseQueryHook(StoreContext, React)
+",
+    true,
+  ],
+  Array [
+    "index",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+export * from \\"./UserModel\\"
+export * from \\"./BookModel\\"
+export * from \\"./RootStore\\"
+export * from \\"./reactUtils\\"
+",
+    true,
+  ],
+]
+`;
+
 exports[`union field type to work 1`] = `
 Array [
   Array [

--- a/tests/generator/__snapshots__/generate.test.js.snap
+++ b/tests/generator/__snapshots__/generate.test.js.snap
@@ -2964,6 +2964,253 @@ export * from \\"./reactUtils\\"
 ]
 `;
 
+exports[`uses ID with highest specificity when multiple ID matches using fieldOverrides 1`] = `
+Array [
+  Array [
+    "ModelBase",
+    "import { MSTGQLObject } from \\"mst-gql\\"
+
+export const ModelBase = MSTGQLObject
+",
+    false,
+  ],
+  Array [
+    "UserModel.base",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+import { types } from \\"mobx-state-tree\\"
+import { QueryBuilder } from \\"mst-gql\\"
+import { ModelBase } from \\"./ModelBase\\"
+import { RootStoreType } from \\"./index\\"
+
+
+/**
+ * UserBase
+ * auto generated base class for the model UserModel.
+ */
+export const UserModelBase = ModelBase
+  .named('User')
+  .props({
+    __typename: types.optional(types.literal(\\"User\\"), \\"User\\"),
+    id: types.union(types.undefined, types.frozen()),
+    user_id: types.identifier,
+    name: types.union(types.undefined, types.string),
+  })
+  .views(self => ({
+    get store() {
+      return self.__getStore<RootStoreType>()
+    }
+  }))
+
+export class UserModelSelector extends QueryBuilder {
+  get id() { return this.__attr(\`id\`) }
+  get user_id() { return this.__attr(\`user_id\`) }
+  get name() { return this.__attr(\`name\`) }
+}
+export function selectFromUser() {
+  return new UserModelSelector()
+}
+
+export const userModelPrimitives = selectFromUser().user_id.name
+",
+    true,
+  ],
+  Array [
+    "UserModel",
+    "import { Instance } from \\"mobx-state-tree\\"
+import { UserModelBase } from \\"./UserModel.base\\"
+
+/* The TypeScript type of an instance of UserModel */
+export interface UserModelType extends Instance<typeof UserModel.Type> {}
+
+/* A graphql query fragment builders for UserModel */
+export { selectFromUser, userModelPrimitives, UserModelSelector } from \\"./UserModel.base\\"
+
+/**
+ * UserModel
+ */
+export const UserModel = UserModelBase
+  .actions(self => ({
+    // This is an auto-generated example action.
+    log() {
+      console.log(JSON.stringify(self))
+    }
+  }))
+",
+    false,
+  ],
+  Array [
+    "BookModel.base",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+import { types } from \\"mobx-state-tree\\"
+import { QueryBuilder } from \\"mst-gql\\"
+import { ModelBase } from \\"./ModelBase\\"
+import { RootStoreType } from \\"./index\\"
+
+
+/**
+ * BookBase
+ * auto generated base class for the model BookModel.
+ */
+export const BookModelBase = ModelBase
+  .named('Book')
+  .props({
+    __typename: types.optional(types.literal(\\"Book\\"), \\"Book\\"),
+    id: types.union(types.undefined, types.frozen()),
+    book_id: types.identifier,
+    name: types.union(types.undefined, types.string),
+  })
+  .views(self => ({
+    get store() {
+      return self.__getStore<RootStoreType>()
+    }
+  }))
+
+export class BookModelSelector extends QueryBuilder {
+  get id() { return this.__attr(\`id\`) }
+  get book_id() { return this.__attr(\`book_id\`) }
+  get name() { return this.__attr(\`name\`) }
+}
+export function selectFromBook() {
+  return new BookModelSelector()
+}
+
+export const bookModelPrimitives = selectFromBook().book_id.name
+",
+    true,
+  ],
+  Array [
+    "BookModel",
+    "import { Instance } from \\"mobx-state-tree\\"
+import { BookModelBase } from \\"./BookModel.base\\"
+
+/* The TypeScript type of an instance of BookModel */
+export interface BookModelType extends Instance<typeof BookModel.Type> {}
+
+/* A graphql query fragment builders for BookModel */
+export { selectFromBook, bookModelPrimitives, BookModelSelector } from \\"./BookModel.base\\"
+
+/**
+ * BookModel
+ */
+export const BookModel = BookModelBase
+  .actions(self => ({
+    // This is an auto-generated example action.
+    log() {
+      console.log(JSON.stringify(self))
+    }
+  }))
+",
+    false,
+  ],
+  Array [
+    "RootStore",
+    "import { Instance } from \\"mobx-state-tree\\"
+import { RootStoreBase } from \\"./RootStore.base\\"
+
+export interface RootStoreType extends Instance<typeof RootStore.Type> {}
+
+export const RootStore = RootStoreBase
+  .actions(self => ({
+    // This is an auto-generated example action.
+    log() {
+      console.log(JSON.stringify(self))
+    }
+  }))
+",
+    false,
+  ],
+  Array [
+    "RootStore.base",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+import { ObservableMap } from \\"mobx\\"
+import { types } from \\"mobx-state-tree\\"
+import { MSTGQLStore, configureStoreMixin, QueryOptions, withTypedRefs } from \\"mst-gql\\"
+
+import { UserModel, UserModelType } from \\"./UserModel\\"
+import { userModelPrimitives, UserModelSelector } from \\"./UserModel.base\\"
+import { BookModel, BookModelType } from \\"./BookModel\\"
+import { bookModelPrimitives, BookModelSelector } from \\"./BookModel.base\\"
+
+
+/* The TypeScript type that explicits the refs to other models in order to prevent a circular refs issue */
+type Refs = {
+  users: ObservableMap<string, UserModelType>
+}
+
+
+/**
+* Enums for the names of base graphql actions
+*/
+export enum RootStoreBaseQueries {
+queryMe=\\"queryMe\\",
+queryBook=\\"queryBook\\"
+}
+
+
+/**
+* Store, managing, among others, all the objects received through graphQL
+*/
+export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
+  .named(\\"RootStore\\")
+  .extend(configureStoreMixin([['User', () => UserModel], ['Book', () => BookModel]], ['User'], \\"js\\"))
+  .props({
+    users: types.optional(types.map(types.late((): any => UserModel)), {})
+  })
+  .actions(self => ({
+    queryMe(variables?: {  }, resultSelector: string | ((qb: UserModelSelector) => UserModelSelector) = userModelPrimitives.toString(), options: QueryOptions = {}) {
+      return self.query<{ me: UserModelType}>(\`query me { me {
+        \${typeof resultSelector === \\"function\\" ? resultSelector(new UserModelSelector()).toString() : resultSelector}
+      } }\`, variables, options)
+    },
+    queryBook(variables?: {  }, resultSelector: string | ((qb: BookModelSelector) => BookModelSelector) = bookModelPrimitives.toString(), options: QueryOptions = {}) {
+      return self.query<{ book: BookModelType}>(\`query book { book {
+        \${typeof resultSelector === \\"function\\" ? resultSelector(new BookModelSelector()).toString() : resultSelector}
+      } }\`, variables, options)
+    },
+  })))
+",
+    true,
+  ],
+  Array [
+    "reactUtils",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+import { createStoreContext, createUseQueryHook } from \\"mst-gql\\"
+import * as React from \\"react\\"
+import { RootStoreType } from \\"./RootStore\\"
+
+export const StoreContext = createStoreContext<RootStoreType>(React)
+
+export const useQuery = createUseQueryHook(StoreContext, React)
+",
+    true,
+  ],
+  Array [
+    "index",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+export * from \\"./UserModel\\"
+export * from \\"./BookModel\\"
+export * from \\"./RootStore\\"
+export * from \\"./reactUtils\\"
+",
+    true,
+  ],
+]
+`;
+
 exports[`when array is not required, should be optional in TS 1`] = `
 Array [
   Array [

--- a/tests/generator/generate.test.js
+++ b/tests/generator/generate.test.js
@@ -390,3 +390,47 @@ type Mutation {
     )
   ).toMatchSnapshot()
 })
+
+test("use identifierNumber as ID with useIdentifierNumber=true", () => {
+  const schema = `
+    type User {
+      id: ID
+      name: String!
+      avatar: String!
+    }
+
+    input UsersFilter {
+      ids: [ID!]!
+    }
+
+    type Query {
+      user(id: ID!): User!
+      users(input: UsersFilter!) : [User]!
+    }
+  `
+
+  const output = scaffold(schema, {
+    roots: ["User"],
+    useIdentifierNumber: true
+  })
+
+  expect(output).toMatchSnapshot()
+
+  expect(
+    hasFileContent(
+      findFile(output, "UserModel.base"),
+      "id: types.identifierNumber,"
+    )
+  ).toBeTruthy()
+
+  expect(
+    hasFileContent(
+      findFile(output, "RootStore.base"),
+      "queryUser(variables: { id: number },"
+    )
+  ).toBeTruthy()
+
+  expect(
+    hasFileContent(findFile(output, "RootStore.base"), "ids: number[]")
+  ).toBeTruthy()
+})

--- a/tests/generator/generate.test.js
+++ b/tests/generator/generate.test.js
@@ -626,3 +626,39 @@ test("uses ID with highest specificity when multiple ID matches using fieldOverr
     )
   ).toBeTruthy()
 })
+
+test("overrides TS types for query arguments and input types for fields with global type overrides with fieldOverrides", () => {
+  const schema = `
+    scalar uuid
+
+    type User {
+      id: uuid!
+      name: String!
+    }
+
+    input UserInput {
+      user_id: uuid!
+    }
+    type Query {
+      getUser(input: UserInput) : User
+    }
+  `
+
+  const output = scaffold(schema, {
+    roots: ["User"],
+    fieldOverrides: [
+      ["*", "uuid", "identifier"],
+      ["*id", "uuid", "identifierNumber"]
+    ]
+  })
+
+  expect(output).toMatchSnapshot()
+
+  expect(
+    hasFileContent(findFile(output, "UserModel.base"), "id: types.identifier,")
+  ).toBeTruthy()
+
+  expect(
+    hasFileContent(findFile(output, "RootStore.base"), "user_id: string")
+  ).toBeTruthy()
+})

--- a/tests/generator/generate.test.js
+++ b/tests/generator/generate.test.js
@@ -538,3 +538,32 @@ test("overrides mst type with partial wildcard name using fieldOverrides", () =>
     )
   ).toBeTruthy()
 })
+
+test("overrides with multiple matches uses best one when using fieldOverrides", () => {
+  const output = scaffold(fieldOverridesSchema, {
+    roots: ["User"],
+    fieldOverrides: [
+      ["*", "bigint", "identifier"],
+      ["id", "bigint", "identifierNumber"],
+
+      ["id", "uuid", "identifier"],
+      ["Book.id", "*", "identifierNumber"]
+    ]
+  })
+
+  expect(output).toMatchSnapshot()
+
+  expect(
+    hasFileContent(
+      findFile(output, "UserModel.base"),
+      "id: types.identifierNumber,"
+    )
+  ).toBeTruthy()
+
+  expect(
+    hasFileContent(
+      findFile(output, "BookModel.base"),
+      "id: types.identifierNumber,"
+    )
+  ).toBeTruthy()
+})


### PR DESCRIPTION
@chrisdrackett 
Attempts to add workarounds for #223 and #92 

Adds two new scaffolding options:
`--useIdentifierNumber`: Specifying this option will use `identifierNumber` instead of `identifier` for all GQL ID types project wide. 
`--fieldOverrides gqlFieldName:gqlFieldType:mstType,...`: draws largely from the proposal in [this comment](https://github.com/mobxjs/mst-gql/issues/92#issue-493537797) The explanation in the README is hopefully sufficient, but it may need to be tweaked as its pretty verbose. The explanation is as follows:

`--fieldOverrides id:uuid:idenfitier,*:ID:identifierNumber` Overrides default MST types for matching GraphQL names and types. The format is `gqlFieldName:gqlFieldType:mstType`. Supports full or partial wildcards for fieldNames, and full wildcards for fieldTypes. Case Sensitive. If multiple matches occur, the match with the least amount of wildcards will be used, followd by the order specified in the arg list if there are still multiple matches. Some examples:

  - `*_id:*:string` - Matches any GQL type with the field name `*_id` (like `user_id`), and uses the MST type `types.string`
  - `*:ID:identifierNumber` - Matches any GQL type with any field name and the `ID` type, and uses the MST type `types.identifierNumber`
  - `User.user_id:ID:number` - Matches the `user_id` field on `User` with the GQL type `ID`, and uses the MST type `types.number`

    Specifying this argument additionaly allows the use of multiple IDs on a type. The best matched ID will be used, setting the other IDs to `types.frozen()`

  - `Book.author_id:ID:identifierNumber` - Matches the `author_id` field on `Book` with the GQL type `ID` and uses the MST type `types.identifierNumber`, and sets any other GQL IDs on `Book` to `types.frozen()`

    For TS users, input types and query arguments will only be modified for fieldOverrides with a wildcard for `gqlFieldName` (`*:uuid:identifier`). An override like `*_id:uuid:identifier` will not affect input types.

    The primary use case for this feature is for GQL Servers that don't always do what you want. For example, Hasura does not generate GQL ID types for UUID fields, which causes issues when trying to reference associate types in MST. To overcome this, simply specify `--fieldOverrides *:UUID:identifier`

My main concerns around this PR:
1. The logic to determine which match has the highest precedence isn't the easiest to follow.
2. How to handle TS for this problem isn't well defined, so the current implementation only overrides TS types for overrides that specify a wildcard for GQLType, like `*:uuid:identifier`. Usage of this is feature is needed to determine what the final functionality should be.