### PR TITLE
onError Fixes

### DIFF
--- a/generator/generate.js
+++ b/generator/generate.js
@@ -786,9 +786,9 @@ ${enumContent}
         "subscription",
         "subscribe",
         format === "ts"
-          ? `, onData?: (item: any) => void` /* TODO: fix the any */
-          : `, onData`,
-        ", onData"
+          ? `, onData?: (item: any) => void, onError?: (error: Error) => void` /* TODO: fix the any */
+          : `, onData, onError`,
+        ", onData, onError"
       )
     )
   }

--- a/src/MSTGQLStore.ts
+++ b/src/MSTGQLStore.ts
@@ -117,7 +117,7 @@ export const MSTGQLStore = types
         throw error
       }
     ): () => void {
-      if (!gqlWsClient) onError(new Error("No WS client available"))
+      if (!gqlWsClient) throw new Error("No WS client available")
       const sub = gqlWsClient
         .request({
           query,
@@ -126,7 +126,7 @@ export const MSTGQLStore = types
         .subscribe({
           next(data) {
             if (data.errors) {
-              onError(new Error(JSON.stringify(data.errors)))
+              return onError(new Error(JSON.stringify(data.errors)))
             }
             ;(self as any).__runInStoreContext(() => {
               const res = (self as any).merge(getFirstValue(data.data))


### PR DESCRIPTION
@chrisdrackett Sorry, this is a couple of minor fixes to follow up https://github.com/mobxjs/mst-gql/pull/261

- Returns after calling `onError` when handling a subscription message to prevent falling through to invalid code that assumes no errors
- Updates the subscription generator to allow `onError` to be passed down