### PR TITLE
Fix scaffolding on npm install

### DIFF
--- a/generator/mst-gql-scaffold.js
+++ b/generator/mst-gql-scaffold.js
@@ -69,7 +69,7 @@ function main() {
   let json
   if (input.startsWith("http:") || input.startsWith("https:")) {
     const tmpFile = "tmp_schema.json"
-    const command = `${__dirname}/../node_modules/.bin/apollo client:download-schema --endpoint=${input} ${tmpFile} ${
+    const command = `${__dirname}/../../.bin/apollo client:download-schema --endpoint=${input} ${tmpFile} ${
       header ? `--header=${header}` : "" // the header options MUST be after the output 0_o
     }`
     child_process.execSync(command)


### PR DESCRIPTION
Fixes  #208

When installed with npm the `node_modules` folder has a different structure, therefore we should use the one that is common between npm and yarn.