### PR TITLE
Add clear method to Query

### DIFF
--- a/src/Query.ts
+++ b/src/Query.ts
@@ -93,7 +93,7 @@ export class Query<T = unknown> implements PromiseLike<T> {
     }
   }
 
-  clear = (): void => {
+  clearData = (): void => {
     action(() => {
       this.data = undefined
     })

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -93,6 +93,12 @@ export class Query<T = unknown> implements PromiseLike<T> {
     }
   }
 
+  clear = (): void => {
+    action(() => {
+      this.data = undefined
+    })
+  }
+
   refetch = (): Promise<T> => {
     return Promise.resolve().then(
       action(() => {


### PR DESCRIPTION
This is related to the issue #273 which adds a clear method to be able to reset the query to undefined again after fetching.