### PR TITLE
Fix for circular types on relation fields

### DIFF
--- a/generator/generate.js
+++ b/generator/generate.js
@@ -510,10 +510,9 @@ ${generateFragments(name, primitiveFields, nonPrimitiveFields)}
           // TODO: split field type resolvement from model properties output
           addImport(subTypeClassName, subTypeClassName)
         }
-        const isSelf = fieldType.name === currentType
         // always using late prevents potential circular dependency issues between files
         return `types.late(()${
-          isSelf && format === "ts" ? ": any" : ""
+          format === "ts" ? ": any" : ""
         } => ${subTypeClassName})`
       })
       return `types.union(${mstUnionArgs.join(", ")})`

--- a/tests/generator/__snapshots__/generate.test.js.snap
+++ b/tests/generator/__snapshots__/generate.test.js.snap
@@ -1184,7 +1184,7 @@ export const RepoModelBase = ModelBase
   .props({
     __typename: types.optional(types.literal(\\"Repo\\"), \\"Repo\\"),
     id: types.identifier,
-    owner: types.union(types.undefined, types.null, types.union(types.late(() => UserModel), types.late(() => OrganizationModel))),
+    owner: types.union(types.undefined, types.null, types.union(types.late((): any => UserModel), types.late((): any => OrganizationModel))),
   })
   .views(self => ({
     get store() {
@@ -1693,7 +1693,7 @@ export const SearchResultModelBase = ModelBase
   .props({
     __typename: types.optional(types.literal(\\"SearchResult\\"), \\"SearchResult\\"),
     inputQuery: types.union(types.undefined, types.string),
-    items: types.union(types.undefined, types.array(types.union(types.null, types.union(types.late(() => MovieModel), types.late(() => BookModel))))),
+    items: types.union(types.undefined, types.array(types.union(types.null, types.union(types.late((): any => MovieModel), types.late((): any => BookModel))))),
   })
   .views(self => ({
     get store() {

--- a/tests/generator/generate.test.js
+++ b/tests/generator/generate.test.js
@@ -146,7 +146,7 @@ type Query {
   expect(
     hasFileContent(
       repoModelBase,
-      "owner: types.union(types.undefined, types.null, types.union(types.late(() => UserModel), types.late(() => OrganizationModel))),"
+      "owner: types.union(types.undefined, types.null, types.union(types.late((): any => UserModel), types.late((): any => OrganizationModel))),"
     )
   ).toBeTruthy()
 })
@@ -185,7 +185,7 @@ type Query {
   expect(
     hasFileContent(
       searchResultBase,
-      "items: types.union(types.undefined, types.array(types.union(types.null, types.union(types.late(() => MovieModel), types.late(() => BookModel))))),"
+      "items: types.union(types.undefined, types.array(types.union(types.null, types.union(types.late((): any => MovieModel), types.late((): any => BookModel))))),"
     )
   ).toBeTruthy()
 })


### PR DESCRIPTION
Fixes #297.

This resolves the issue in my codebase, but I'm very unconfident in this PR because I admittedly do not understand why there is the `isSelf` check before applying the `: any`. Feel free to close this if there's a better fix.

Thank you!