### PR TITLE
Fix 'id' getter MSTGQLRef 

### DIFF
--- a/src/MSTGQLObject.ts
+++ b/src/MSTGQLObject.ts
@@ -15,8 +15,12 @@ import { StoreType } from "./MSTGQLStore"
 */
 const MSTGQL_ID_DELIM = "::"
 export function getMSTGQLRefLabelAndId(labeledId: string) {
-  const [label, ...id] = labeledId.split(MSTGQL_ID_DELIM)
-  return { label, id: id.join("") || labeledId }
+  if (labeledId.includes(MSTGQL_ID_DELIM)) {
+    const [label, ...id] = labeledId.split(MSTGQL_ID_DELIM)
+    return { label, id: id.join("") }
+  }
+
+  return { label: null, id: labeledId }
 }
 
 export function MSTGQLRef<T extends IAnyModelType>(

--- a/src/MSTGQLObject.ts
+++ b/src/MSTGQLObject.ts
@@ -16,7 +16,7 @@ import { StoreType } from "./MSTGQLStore"
 const MSTGQL_ID_DELIM = "::"
 export function getMSTGQLRefLabelAndId(labeledId: string) {
   const [label, ...id] = labeledId.split(MSTGQL_ID_DELIM)
-  return { label, id: id.join("") }
+  return { label, id: id.join("") || labeledId }
 }
 
 export function MSTGQLRef<T extends IAnyModelType>(

--- a/tests/lib/unionTypes/todostore.test.js
+++ b/tests/lib/unionTypes/todostore.test.js
@@ -74,4 +74,27 @@ describe("unionTypes tests", () => {
       store2.todoLists.get("c").todos.filter((f) => f.complete)
     ).toHaveLength(1)
   })
+
+  test("it should get todo by reference", () => {
+    const basicTodoItemSnapshot = {
+      id: "custom-item",
+      complete: true,
+      text: "something"
+    }
+
+    const storeSnapshot = {
+      todoLists: {
+        "custom-list": { id: "custom-list", todos: ["custom-item"] }
+      },
+      basicTodos: {
+        [basicTodoItemSnapshot.id]: basicTodoItemSnapshot
+      }
+    }
+
+    const store = models.RootStore.create(storeSnapshot, {})
+
+    expect(store.todoLists.get("custom-list").todos[0].text).toBe(
+      basicTodoItemSnapshot.text
+    )
+  })
 })


### PR DESCRIPTION
This PR contains a small fix for getting the node.id in MSTGQLRef.

**Problem:**
When I create my mobxStore from a snapshot during testing, the models do not call a setter where their id must be modified and a separator added.
```
RootStore.create({
   items: {
       '1': {id: '1', name: 'one'},
       '2': {id: '2', name: 'two'}
   },
   myRef: ['1'] //  MSTGQLRef(types.late((): any => ItemModel)),
})
```
> Also, you can look real example in test https://github.com/mobxjs/mst-gql/pull/319/files#diff-8da68bbe119c10527a005b652d591c418c435a78af66333be4e4608e5fc3cc72 

I got:  `Failed to resolve reference   to late(() => ItemModel.ItemModel)`, as you can see without id becouse id in this case just empty space `''`

So, this happens because in this case not fires this code: https://github.com/mobxjs/mst-gql/blob/main/src/MSTGQLObject.ts#L41-L43

And my solution will fix that, although I'm not sure if it's the right solution, but it works for me and theoretically can't cause problems.