### PR TITLE
Improving merge strategy (3х performance increase, and 5x memory allocate decrease)

### DIFF
--- a/src/mergeHelper.ts
+++ b/src/mergeHelper.ts
@@ -1,44 +1,86 @@
-import { resolveIdentifier } from "mobx-state-tree"
-import { typenameToCollectionName } from "./utils"
+import { isNumber, isObject } from "lodash"
+import { resolveIdentifier, getSnapshot } from "mobx-state-tree"
 
-export function mergeHelper(store: any, data: any) {
-  function merge(data: any): any {
+// use a proxy for array-type structures, saves huge amounts of memory, and improves performance
+const proxyHandler = (store: any) => ({
+  get(target: any, prop: any, receiver: any) {
+    const instance = Reflect.get(target, prop, receiver) as any
+
+    if (isNumber(prop)) return instance
+
+    const { __typename, id } = instance
+    const typeDef = store.getTypeDef(__typename)
+
+    return id !== undefined ? resolveIdentifier(typeDef, store, id) : instance
+  }
+})
+
+export function mergeHelper(store: any, initialData: any): any {
+  const reactiveResult: any = {}
+
+  function merge(data: any, depth = 0, prevKey = ""): any {
     if (!data || typeof data !== "object") return data
-    if (Array.isArray(data)) return data.map(merge)
+    if (Array.isArray(data)) return data.map((d) => merge(d, depth, prevKey))
 
     const { __typename, id } = data
+    const snapshot: any = {}
 
     // convert values deeply first to MST objects as much as possible
-    const snapshot: any = {}
     for (const key in data) {
-      snapshot[key] = merge(data[key])
+      if (isObject(data[key]) || Array.isArray(data[key])) {
+        snapshot[key] = merge(data[key], depth + 1, key)
+      } else {
+        snapshot[key] = data[key]
+      }
     }
 
-    // GQL object
     if (__typename && store.isKnownType(__typename)) {
-      // GQL object with known type, instantiate or recycle MST object
-      const typeDef = store.getTypeDef(__typename)
-      // Try to reuse instance, even if it is not a root type
-      let instance = id !== undefined && resolveIdentifier(typeDef, store, id)
-      if (instance) {
+      // process with root types
+      if (store.isRootType(__typename)) {
+        const rootMap = store[store.getCollectionName(__typename)]
+        const instance = rootMap.get(id)
         // update existing object
-        Object.assign(instance, snapshot)
-      } else {
-        // create a new one
-        instance = typeDef.create(snapshot)
-        if (store.isRootType(__typename)) {
-          // register in the store if a root
-          //store[typenameToCollectionName(__typename)].set(id, instance)
-          store[store.getCollectionName(__typename)].set(id, instance)
+        const newInstance = {
+          ...(instance ? getSnapshot<Object>(instance) : {}),
+          ...snapshot
         }
+        // register in the store if a root
+        rootMap.set(id, newInstance)
+      } else {
+        // try create a new one and return non root type model
+        const typeDef = store.getTypeDef(__typename)
+        const instance = typeDef.create(snapshot)
         instance.__setStore(store)
+
+        return instance
       }
-      return instance
-    } else {
-      // GQL object with unknown type, return verbatim
-      return snapshot
     }
+
+    // build reactive structure as result this merge logic,
+    // only for the first keys in the gql response, this is sufficient
+    // as the rest of the tree will be reactive due to the mst structure
+    if (depth === 1 && prevKey) {
+      if (!reactiveResult[prevKey]) {
+        reactiveResult[prevKey] = Array.isArray(initialData[prevKey])
+          ? new Proxy([], proxyHandler(store))
+          : {}
+      }
+
+      if (Array.isArray(initialData[prevKey])) {
+        reactiveResult[prevKey].push(snapshot)
+      } else {
+        const typeDef = store.getTypeDef(__typename)
+        const instance = typeDef
+          ? resolveIdentifier(typeDef, store, id)
+          : snapshot
+        reactiveResult[prevKey] = instance
+      }
+    }
+
+    return __typename && store.isRootType(__typename) ? id : snapshot
   }
 
-  return merge(data)
+  merge(initialData)
+
+  return reactiveResult
 }

--- a/src/mergeHelper.ts
+++ b/src/mergeHelper.ts
@@ -18,7 +18,11 @@ const proxyHandler = (store: any) => ({
 // prepare reactive results with proxies and for any depth
 function buildResponse(data: any, store: any) {
   if (!data || typeof data !== "object") return data
-  if (Array.isArray(data)) return new Proxy(data, proxyHandler(store))
+  if (Array.isArray(data))
+    return new Proxy(
+      Object.isFrozen(data) ? Array.from(data) : data,
+      proxyHandler(store)
+    )
 
   const { __typename, id } = data
 


### PR DESCRIPTION
Hi all, let me introduce my idea and improvement of the current merge logic.

**Reason:**
I noticed in my application had a performance problem and memory leaks. It was because the merge logic was doing double work, long story short on each iteration of the loop, we created a model in mst and then converted the newly created model into the graphql response structure. 
For example: 
We requested 100 entities, and we got this as an array response:
```
   entites: [{entity1}, {entity2}, {entity3}, ..., etc]
```
Then we would create each such entity in the `mst.map` structure, and from there convert it to an array.
Which is the bottleneck of mst as we have created a copy of the reactive data (array of entites in our case)

it starts to be noticeable when we have an array with 1000 entities in the response 

It seems that the author of this [issue](https://github.com/mobxjs/mobx-state-tree/issues/1683) also has the same problem and also works with mst-gql.

**My solution**
1. I used Proxy to get the mobx-model while reading and not while writing (merge), this saves a lot of memory and is the main idea. (it's apply only for arrays, everything else computed as before.)

2. I rewrote the recursive merge logic to avoid frequent recalculations of reactive models, and left it only for root data, which also makes sense since root data if linked to mst-tree, will be automaticle reactive.

This has been working for a few days in my project and seems to be working fine, but please test it on your projects and post here any issues, I think it can significantly increase the performance of your applications. I would be happy to get feedback. 

PS: I will prepare a comparison of the two approaches later.
