### PR TITLE
Introduced support for AbortController in GraphQL HTTP requests

### DIFF
--- a/examples/2-scaffolding/package.json
+++ b/examples/2-scaffolding/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "mobx": "^5.9.4",
     "mobx-state-tree": "^3.14.0",
-    "mst-gql": "latest"
+    "mst-gql": "latest",
+    "graphql-request": "^4.0.0"
   },
   "devDependencies": {
     "@types/react": "^16.8.18",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "cosmiconfig": "^7.0.0",
     "fast-json-stable-stringify": "^2.1.0",
     "graphql": "14.6.0",
-    "graphql-request": "^3.4.0",
+    "graphql-request": "^4.0.0",
     "lodash": "^4.17.21",
     "pluralize": "^8.0.0",
     "throttle-debounce": "^3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4579,10 +4579,10 @@ graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
-graphql-request@^3.4.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-3.5.0.tgz#7e69574e15875fb3f660a4b4be3996ecd0bbc8b7"
-  integrity sha512-Io89QpfU4rqiMbqM/KwMBzKaDLOppi8FU8sEccCE4JqCgz95W9Q8bvxQ4NfPALLSMvg9nafgg8AkYRmgKSlukA==
+graphql-request@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-4.0.0.tgz#5e4361d33df1a95ccd7ad23a8ebb6bbca9d5622f"
+  integrity sha512-cdqQLCXlBGkaLdkLYRl4LtkwaZU6TfpE7/tnUQFl3wXfUPWN74Ov+Q61VuIh+AltS789YfGB6whghmCmeXLvTw==
   dependencies:
     cross-fetch "^3.0.6"
     extract-files "^9.0.0"


### PR DESCRIPTION
The PR bumps up `graphql-request` and introduces cancelling GraphQL requests based on changes in `graphql-request`.