### PR TITLE
Add --dynamicArgs option to generate operation arguments dynamically

### DIFF
--- a/generator/config.js
+++ b/generator/config.js
@@ -16,7 +16,8 @@ exports.defaultConfig = {
   namingConvention: "js", // supported option: "js", "asis",
   header: undefined,
   useIdentifierNumber: false,
-  fieldOverrides: []
+  fieldOverrides: [],
+  dynamicArgs: false
 }
 
 exports.getConfig = function getConfig() {
@@ -58,7 +59,8 @@ exports.mergeConfigs = function mergeConfigs(args, config) {
       !!args["--useIdentifierNumber"] || config.useIdentifierNumber,
     fieldOverrides: args["--fieldOverrides"]
       ? parseFieldOverrides(args["--fieldOverrides"])
-      : config.fieldOverrides
+      : config.fieldOverrides,
+    dynamicArgs: !!args["--dynamicArgs"] || config.dynamicArgs
   }
 }
 

--- a/generator/mst-gql-scaffold.js
+++ b/generator/mst-gql-scaffold.js
@@ -20,7 +20,8 @@ const definition = {
   "--dontRenameModels": Boolean,
   "--header": String,
   "--useIdentifierNumber": Boolean,
-  "--fieldOverrides": String
+  "--fieldOverrides": String,
+  "--dynamicArgs": Boolean
 }
 
 function main() {
@@ -49,7 +50,8 @@ function main() {
     namingConvention,
     header,
     useIdentifierNumber,
-    fieldOverrides
+    fieldOverrides,
+    dynamicArgs
   } = mergeConfigs(args, config)
   const separate = !!args["--separate"]
 
@@ -114,7 +116,8 @@ function main() {
     noReact,
     namingConvention,
     useIdentifierNumber,
-    fieldOverrides
+    fieldOverrides,
+    dynamicArgs
   )
   writeFiles(outDir, files, format, forceAll, true, separate)
   logUnexpectedFiles(outDir, files)


### PR DESCRIPTION
Fixes #362 (Should be merged after #361)

Originally for any graphql operation with arguments every formal and actual
argument has been generated into the corresponding function in
RootStore.base.ts.

Using --dynamicArgs or setting in mst-gql.config.js dynamicArgs:true
will cause generation of operation functions, which will create graphql
operations, which only define those arguments, which have a matching
variable set in "variables". This dynamic argument generation solves issues
with Hasura mutations as well.