### PR TITLE
Upgrade graphql package

### DIFF
--- a/examples/2-scaffolding/package.json
+++ b/examples/2-scaffolding/package.json
@@ -18,7 +18,7 @@
     "@types/react-dom": "^16.8.4",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "typescript": "^3.4.5"
+    "typescript": "^4.6.4"
   },
   "relativeDependencies": {
     "mst-gql": "../../"

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -1289,9 +1289,6 @@ function scaffold(
 ) {
 
   const schema = graphql.buildSchema(definition)
-  //console.log("+++ schema", definition)
-  // console.log("+++ introspectionQuery", graphql.introspectionQuery, getIntrospectionQuery())
-  //const res = graphql.graphqlSync(schema, getIntrospectionQuery())
   const res = graphql.graphqlSync({schema, source: getIntrospectionQuery()})
   if (!res.data)
     throw new Error("graphql parse error:\n\n" + JSON.stringify(res, null, 2))

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -4,6 +4,7 @@ const graphql = require("graphql")
 const camelcase = require("camelcase")
 const pluralize = require("pluralize")
 const escapeStringRegexp = require("escape-string-regexp")
+const { getIntrospectionQuery } = require("graphql")
 
 const exampleAction = `  .actions(self => ({
     // This is an auto-generated example action.
@@ -1262,8 +1263,12 @@ function scaffold(
     fieldOverrides: []
   }
 ) {
+
   const schema = graphql.buildSchema(definition)
-  const res = graphql.graphqlSync(schema, graphql.introspectionQuery)
+  //console.log("+++ schema", definition)
+  // console.log("+++ introspectionQuery", graphql.introspectionQuery, getIntrospectionQuery())
+  //const res = graphql.graphqlSync(schema, getIntrospectionQuery())
+  const res = graphql.graphqlSync({schema, source: getIntrospectionQuery()})
   if (!res.data)
     throw new Error("graphql parse error:\n\n" + JSON.stringify(res, null, 2))
   return generate(

--- a/generator/mst-gql-scaffold.js
+++ b/generator/mst-gql-scaffold.js
@@ -4,6 +4,7 @@ const path = require("path")
 const fs = require("fs")
 const child_process = require("child_process")
 const graphql = require("graphql")
+const { getIntrospectionQuery } = require("graphql")
 
 const { getConfig, mergeConfigs } = require("./config")
 const { generate, writeFiles, logUnexpectedFiles } = require("./generate")
@@ -85,7 +86,7 @@ function main() {
     // Tnx https://blog.apollographql.com/three-ways-to-represent-your-graphql-schema-a41f4175100d!
     const text = fs.readFileSync(input, "utf8")
     const schema = graphql.buildSchema(text)
-    const res = graphql.graphqlSync(schema, graphql.introspectionQuery)
+    const res = graphql.graphqlSync({schema, source: getIntrospectionQuery()})
     if (res.data) json = res.data
     else {
       console.error("graphql parse error:\n\n" + JSON.stringify(res, null, 2))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mst-gql",
-  "version": "0.15.0",
+  "version": "0.15.0-graphql-upgrade",
   "description": "Bindings for mobx-state-tree and GraphQL",
   "author": "Michel Weststrate",
   "keywords": [
@@ -48,8 +48,8 @@
     "camelcase": "^6.2.0",
     "cosmiconfig": "^7.0.0",
     "fast-json-stable-stringify": "^2.1.0",
-    "graphql": "14.6.0",
-    "graphql-request": "^4.0.0",
+    "graphql": "^16.3.0",
+    "graphql-request": "^4.2.0",
     "lodash": "^4.17.21",
     "pluralize": "^8.0.0",
     "throttle-debounce": "^3.0.1"
@@ -90,6 +90,6 @@
     "mobx-state-tree": "^5.0.1"
   },
   "resolutions": {
-    "graphql": "14.6.0"
+    "graphql": "^16.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mst-gql",
-  "version": "0.15.0-graphql-upgrade",
+  "version": "0.15.0-361-graphql-upgrade",
   "description": "Bindings for mobx-state-tree and GraphQL",
   "author": "Michel Weststrate",
   "keywords": [
@@ -31,7 +31,7 @@
     "generator"
   ],
   "scripts": {
-    "test": "jest test && cd examples/2-scaffolding && yarn && yarn start && cd ../6-scaffolding-ts-hasura && yarn && yarn start ",
+    "test": "jest test && cd examples/2-scaffolding && yarn && yarn start && cd ../6-scaffolding-ts-hasura && yarn && yarn start && cd ../../tests && ./test-cra.sh && rm -rf cra-test",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",
     "watch": "jest test --watch",
     "build": "microbundle --no-compress --external mobx,mobx-react,mobx-state-tree,graphql-tag,graphql,react,react-dom,graphql-request",

--- a/tests/generator/__snapshots__/generate.test.js.snap
+++ b/tests/generator/__snapshots__/generate.test.js.snap
@@ -183,76 +183,6 @@ export const ModelBase = MSTGQLObject
     false,
   ],
   Array [
-    "QueryRootModel.base",
-    "/* This is a mst-gql generated file, don't modify it manually */
-/* eslint-disable */
-/* tslint:disable */
-
-import { types } from \\"mobx-state-tree\\"
-import { MSTGQLRef, QueryBuilder, withTypedRefs } from \\"mst-gql\\"
-import { ModelBase } from \\"./ModelBase\\"
-import { MyUserModel, MyUserModelType } from \\"./MyUserModel\\"
-import { MyUserModelSelector } from \\"./MyUserModel.base\\"
-import { RootStoreType } from \\"./index\\"
-
-
-/* The TypeScript type that explicits the refs to other models in order to prevent a circular refs issue */
-type Refs = {
-  me: MyUserModelType;
-}
-
-/**
- * QueryRootBase
- * auto generated base class for the model QueryRootModel.
- */
-export const QueryRootModelBase = withTypedRefs<Refs>()(ModelBase
-  .named('QueryRoot')
-  .props({
-    __typename: types.optional(types.literal(\\"query_root\\"), \\"query_root\\"),
-    me: types.union(types.undefined, types.null, MSTGQLRef(types.late((): any => MyUserModel))),
-  })
-  .views(self => ({
-    get store() {
-      return self.__getStore<RootStoreType>()
-    }
-  })))
-
-export class QueryRootModelSelector extends QueryBuilder {
-  me(builder: string | MyUserModelSelector | ((selector: MyUserModelSelector) => MyUserModelSelector) | undefined) { return this.__child(\`me\`, MyUserModelSelector, builder) }
-}
-export function selectFromQueryRoot() {
-  return new QueryRootModelSelector()
-}
-
-export const queryRootModelPrimitives = selectFromQueryRoot()
-",
-    true,
-  ],
-  Array [
-    "QueryRootModel",
-    "import { Instance } from \\"mobx-state-tree\\"
-import { QueryRootModelBase } from \\"./QueryRootModel.base\\"
-
-/* The TypeScript type of an instance of QueryRootModel */
-export interface QueryRootModelType extends Instance<typeof QueryRootModel.Type> {}
-
-/* A graphql query fragment builders for QueryRootModel */
-export { selectFromQueryRoot, queryRootModelPrimitives, QueryRootModelSelector } from \\"./QueryRootModel.base\\"
-
-/**
- * QueryRootModel
- */
-export const QueryRootModel = QueryRootModelBase
-  .actions(self => ({
-    // This is an auto-generated example action.
-    log() {
-      console.log(JSON.stringify(self))
-    }
-  }))
-",
-    false,
-  ],
-  Array [
     "MyUserModel.base",
     "/* This is a mst-gql generated file, don't modify it manually */
 /* eslint-disable */
@@ -397,6 +327,76 @@ export const PossiblyEmptyBoxModel = PossiblyEmptyBoxModelBase
     false,
   ],
   Array [
+    "QueryRootModel.base",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+import { types } from \\"mobx-state-tree\\"
+import { MSTGQLRef, QueryBuilder, withTypedRefs } from \\"mst-gql\\"
+import { ModelBase } from \\"./ModelBase\\"
+import { MyUserModel, MyUserModelType } from \\"./MyUserModel\\"
+import { MyUserModelSelector } from \\"./MyUserModel.base\\"
+import { RootStoreType } from \\"./index\\"
+
+
+/* The TypeScript type that explicits the refs to other models in order to prevent a circular refs issue */
+type Refs = {
+  me: MyUserModelType;
+}
+
+/**
+ * QueryRootBase
+ * auto generated base class for the model QueryRootModel.
+ */
+export const QueryRootModelBase = withTypedRefs<Refs>()(ModelBase
+  .named('QueryRoot')
+  .props({
+    __typename: types.optional(types.literal(\\"query_root\\"), \\"query_root\\"),
+    me: types.union(types.undefined, types.null, MSTGQLRef(types.late((): any => MyUserModel))),
+  })
+  .views(self => ({
+    get store() {
+      return self.__getStore<RootStoreType>()
+    }
+  })))
+
+export class QueryRootModelSelector extends QueryBuilder {
+  me(builder: string | MyUserModelSelector | ((selector: MyUserModelSelector) => MyUserModelSelector) | undefined) { return this.__child(\`me\`, MyUserModelSelector, builder) }
+}
+export function selectFromQueryRoot() {
+  return new QueryRootModelSelector()
+}
+
+export const queryRootModelPrimitives = selectFromQueryRoot()
+",
+    true,
+  ],
+  Array [
+    "QueryRootModel",
+    "import { Instance } from \\"mobx-state-tree\\"
+import { QueryRootModelBase } from \\"./QueryRootModel.base\\"
+
+/* The TypeScript type of an instance of QueryRootModel */
+export interface QueryRootModelType extends Instance<typeof QueryRootModel.Type> {}
+
+/* A graphql query fragment builders for QueryRootModel */
+export { selectFromQueryRoot, queryRootModelPrimitives, QueryRootModelSelector } from \\"./QueryRootModel.base\\"
+
+/**
+ * QueryRootModel
+ */
+export const QueryRootModel = QueryRootModelBase
+  .actions(self => ({
+    // This is an auto-generated example action.
+    log() {
+      console.log(JSON.stringify(self))
+    }
+  }))
+",
+    false,
+  ],
+  Array [
     "RootStore",
     "import { Instance } from \\"mobx-state-tree\\"
 import { RootStoreBase } from \\"./RootStore.base\\"
@@ -422,12 +422,12 @@ import { ObservableMap } from \\"mobx\\"
 import { types } from \\"mobx-state-tree\\"
 import { MSTGQLStore, configureStoreMixin, QueryOptions, withTypedRefs } from \\"mst-gql\\"
 
-import { QueryRootModel, QueryRootModelType } from \\"./QueryRootModel\\"
-import { queryRootModelPrimitives, QueryRootModelSelector } from \\"./QueryRootModel.base\\"
 import { MyUserModel, MyUserModelType } from \\"./MyUserModel\\"
 import { myUserModelPrimitives, MyUserModelSelector } from \\"./MyUserModel.base\\"
 import { PossiblyEmptyBoxModel, PossiblyEmptyBoxModelType } from \\"./PossiblyEmptyBoxModel\\"
 import { possiblyEmptyBoxModelPrimitives, PossiblyEmptyBoxModelSelector } from \\"./PossiblyEmptyBoxModel.base\\"
+import { QueryRootModel, QueryRootModelType } from \\"./QueryRootModel\\"
+import { queryRootModelPrimitives, QueryRootModelSelector } from \\"./QueryRootModel.base\\"
 
 
 
@@ -449,7 +449,7 @@ type Refs = {
 */
 export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
   .named(\\"RootStore\\")
-  .extend(configureStoreMixin([['query_root', () => QueryRootModel], ['my_user', () => MyUserModel], ['possibly_empty_box', () => PossiblyEmptyBoxModel]], ['my_user', 'possibly_empty_box'], \\"js\\"))
+  .extend(configureStoreMixin([['my_user', () => MyUserModel], ['possibly_empty_box', () => PossiblyEmptyBoxModel], ['query_root', () => QueryRootModel]], ['my_user', 'possibly_empty_box'], \\"js\\"))
   .props({
     myUsers: types.optional(types.map(types.late((): any => MyUserModel)), {}),
     possiblyEmptyBoxes: types.optional(types.map(types.late((): any => PossiblyEmptyBoxModel)), {})
@@ -486,9 +486,9 @@ export const useQuery = createUseQueryHook(StoreContext, React)
 /* eslint-disable */
 /* tslint:disable */
 
-export * from \\"./QueryRootModel\\"
 export * from \\"./MyUserModel\\"
 export * from \\"./PossiblyEmptyBoxModel\\"
+export * from \\"./QueryRootModel\\"
 export * from \\"./RootStore\\"
 export * from \\"./reactUtils\\"
 ",
@@ -1161,76 +1161,6 @@ export const ModelBase = MSTGQLObject
     false,
   ],
   Array [
-    "RepoModel.base",
-    "/* This is a mst-gql generated file, don't modify it manually */
-/* eslint-disable */
-/* tslint:disable */
-
-import { types } from \\"mobx-state-tree\\"
-import { QueryBuilder } from \\"mst-gql\\"
-import { ModelBase } from \\"./ModelBase\\"
-import { OrganizationModel, OrganizationModelType } from \\"./OrganizationModel\\"
-import { OrganizationModelSelector } from \\"./OrganizationModel.base\\"
-import { OwnerModelSelector } from \\"./OwnerModelSelector\\"
-import { UserModel, UserModelType } from \\"./UserModel\\"
-import { UserModelSelector } from \\"./UserModel.base\\"
-import { RootStoreType } from \\"./index\\"
-
-
-/**
- * RepoBase
- * auto generated base class for the model RepoModel.
- */
-export const RepoModelBase = ModelBase
-  .named('Repo')
-  .props({
-    __typename: types.optional(types.literal(\\"Repo\\"), \\"Repo\\"),
-    id: types.identifier,
-    owner: types.union(types.undefined, types.null, types.union(types.late((): any => UserModel), types.late((): any => OrganizationModel))),
-  })
-  .views(self => ({
-    get store() {
-      return self.__getStore<RootStoreType>()
-    }
-  }))
-
-export class RepoModelSelector extends QueryBuilder {
-  get id() { return this.__attr(\`id\`) }
-  owner(builder: string | OwnerModelSelector | ((selector: OwnerModelSelector) => OwnerModelSelector) | undefined) { return this.__child(\`owner\`, OwnerModelSelector, builder) }
-}
-export function selectFromRepo() {
-  return new RepoModelSelector()
-}
-
-export const repoModelPrimitives = selectFromRepo()
-",
-    true,
-  ],
-  Array [
-    "RepoModel",
-    "import { Instance } from \\"mobx-state-tree\\"
-import { RepoModelBase } from \\"./RepoModel.base\\"
-
-/* The TypeScript type of an instance of RepoModel */
-export interface RepoModelType extends Instance<typeof RepoModel.Type> {}
-
-/* A graphql query fragment builders for RepoModel */
-export { selectFromRepo, repoModelPrimitives, RepoModelSelector } from \\"./RepoModel.base\\"
-
-/**
- * RepoModel
- */
-export const RepoModel = RepoModelBase
-  .actions(self => ({
-    // This is an auto-generated example action.
-    log() {
-      console.log(JSON.stringify(self))
-    }
-  }))
-",
-    false,
-  ],
-  Array [
     "OwnerModelSelector",
     "/* This is a mst-gql generated file, don't modify it manually */
 /* eslint-disable */
@@ -1392,6 +1322,76 @@ export const OrganizationModel = OrganizationModelBase
     false,
   ],
   Array [
+    "RepoModel.base",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+import { types } from \\"mobx-state-tree\\"
+import { QueryBuilder } from \\"mst-gql\\"
+import { ModelBase } from \\"./ModelBase\\"
+import { OrganizationModel, OrganizationModelType } from \\"./OrganizationModel\\"
+import { OrganizationModelSelector } from \\"./OrganizationModel.base\\"
+import { OwnerModelSelector } from \\"./OwnerModelSelector\\"
+import { UserModel, UserModelType } from \\"./UserModel\\"
+import { UserModelSelector } from \\"./UserModel.base\\"
+import { RootStoreType } from \\"./index\\"
+
+
+/**
+ * RepoBase
+ * auto generated base class for the model RepoModel.
+ */
+export const RepoModelBase = ModelBase
+  .named('Repo')
+  .props({
+    __typename: types.optional(types.literal(\\"Repo\\"), \\"Repo\\"),
+    id: types.identifier,
+    owner: types.union(types.undefined, types.null, types.union(types.late((): any => UserModel), types.late((): any => OrganizationModel))),
+  })
+  .views(self => ({
+    get store() {
+      return self.__getStore<RootStoreType>()
+    }
+  }))
+
+export class RepoModelSelector extends QueryBuilder {
+  get id() { return this.__attr(\`id\`) }
+  owner(builder: string | OwnerModelSelector | ((selector: OwnerModelSelector) => OwnerModelSelector) | undefined) { return this.__child(\`owner\`, OwnerModelSelector, builder) }
+}
+export function selectFromRepo() {
+  return new RepoModelSelector()
+}
+
+export const repoModelPrimitives = selectFromRepo()
+",
+    true,
+  ],
+  Array [
+    "RepoModel",
+    "import { Instance } from \\"mobx-state-tree\\"
+import { RepoModelBase } from \\"./RepoModel.base\\"
+
+/* The TypeScript type of an instance of RepoModel */
+export interface RepoModelType extends Instance<typeof RepoModel.Type> {}
+
+/* A graphql query fragment builders for RepoModel */
+export { selectFromRepo, repoModelPrimitives, RepoModelSelector } from \\"./RepoModel.base\\"
+
+/**
+ * RepoModel
+ */
+export const RepoModel = RepoModelBase
+  .actions(self => ({
+    // This is an auto-generated example action.
+    log() {
+      console.log(JSON.stringify(self))
+    }
+  }))
+",
+    false,
+  ],
+  Array [
     "RootStore",
     "import { Instance } from \\"mobx-state-tree\\"
 import { RootStoreBase } from \\"./RootStore.base\\"
@@ -1417,12 +1417,12 @@ import { ObservableMap } from \\"mobx\\"
 import { types } from \\"mobx-state-tree\\"
 import { MSTGQLStore, configureStoreMixin, QueryOptions, withTypedRefs } from \\"mst-gql\\"
 
-import { RepoModel, RepoModelType } from \\"./RepoModel\\"
-import { repoModelPrimitives, RepoModelSelector } from \\"./RepoModel.base\\"
 import { UserModel, UserModelType } from \\"./UserModel\\"
 import { userModelPrimitives, UserModelSelector } from \\"./UserModel.base\\"
 import { OrganizationModel, OrganizationModelType } from \\"./OrganizationModel\\"
 import { organizationModelPrimitives, OrganizationModelSelector } from \\"./OrganizationModel.base\\"
+import { RepoModel, RepoModelType } from \\"./RepoModel\\"
+import { repoModelPrimitives, RepoModelSelector } from \\"./RepoModel.base\\"
 
 import { ownerModelPrimitives, OwnerModelSelector , OwnerUnion } from \\"./\\"
 
@@ -1446,7 +1446,7 @@ queryRepo=\\"queryRepo\\"
 */
 export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
   .named(\\"RootStore\\")
-  .extend(configureStoreMixin([['Repo', () => RepoModel], ['User', () => UserModel], ['Organization', () => OrganizationModel]], ['Repo']))
+  .extend(configureStoreMixin([['User', () => UserModel], ['Organization', () => OrganizationModel], ['Repo', () => RepoModel]], ['Repo']))
   .props({
     repos: types.optional(types.map(types.late((): any => RepoModel)), {})
   })
@@ -1482,10 +1482,10 @@ export const useQuery = createUseQueryHook(StoreContext, React)
 /* eslint-disable */
 /* tslint:disable */
 
-export * from \\"./RepoModel\\"
 export * from \\"./OwnerModelSelector\\"
 export * from \\"./UserModel\\"
 export * from \\"./OrganizationModel\\"
+export * from \\"./RepoModel\\"
 export * from \\"./RootStore\\"
 export * from \\"./reactUtils\\"
 ",
@@ -2826,102 +2826,6 @@ export const ModelBase = MSTGQLObject
     false,
   ],
   Array [
-    "SearchResultModel.base",
-    "/* This is a mst-gql generated file, don't modify it manually */
-/* eslint-disable */
-/* tslint:disable */
-
-import { types } from \\"mobx-state-tree\\"
-import { QueryBuilder } from \\"mst-gql\\"
-import { ModelBase } from \\"./ModelBase\\"
-import { BookModel, BookModelType } from \\"./BookModel\\"
-import { BookModelSelector } from \\"./BookModel.base\\"
-import { MovieModel, MovieModelType } from \\"./MovieModel\\"
-import { MovieModelSelector } from \\"./MovieModel.base\\"
-import { SearchItemModelSelector } from \\"./SearchItemModelSelector\\"
-import { RootStoreType } from \\"./index\\"
-
-
-/**
- * SearchResultBase
- * auto generated base class for the model SearchResultModel.
- */
-export const SearchResultModelBase = ModelBase
-  .named('SearchResult')
-  .props({
-    __typename: types.optional(types.literal(\\"SearchResult\\"), \\"SearchResult\\"),
-    inputQuery: types.union(types.undefined, types.string),
-    items: types.union(types.undefined, types.array(types.union(types.null, types.union(types.late((): any => MovieModel), types.late((): any => BookModel))))),
-  })
-  .views(self => ({
-    get store() {
-      return self.__getStore<RootStoreType>()
-    }
-  }))
-
-export class SearchResultModelSelector extends QueryBuilder {
-  get inputQuery() { return this.__attr(\`inputQuery\`) }
-  items(builder: string | SearchItemModelSelector | ((selector: SearchItemModelSelector) => SearchItemModelSelector) | undefined) { return this.__child(\`items\`, SearchItemModelSelector, builder) }
-}
-export function selectFromSearchResult() {
-  return new SearchResultModelSelector()
-}
-
-export const searchResultModelPrimitives = selectFromSearchResult().inputQuery
-",
-    true,
-  ],
-  Array [
-    "SearchResultModel",
-    "import { Instance } from \\"mobx-state-tree\\"
-import { SearchResultModelBase } from \\"./SearchResultModel.base\\"
-
-/* The TypeScript type of an instance of SearchResultModel */
-export interface SearchResultModelType extends Instance<typeof SearchResultModel.Type> {}
-
-/* A graphql query fragment builders for SearchResultModel */
-export { selectFromSearchResult, searchResultModelPrimitives, SearchResultModelSelector } from \\"./SearchResultModel.base\\"
-
-/**
- * SearchResultModel
- */
-export const SearchResultModel = SearchResultModelBase
-  .actions(self => ({
-    // This is an auto-generated example action.
-    log() {
-      console.log(JSON.stringify(self))
-    }
-  }))
-",
-    false,
-  ],
-  Array [
-    "SearchItemModelSelector",
-    "/* This is a mst-gql generated file, don't modify it manually */
-/* eslint-disable */
-/* tslint:disable */
-
-import { QueryBuilder } from \\"mst-gql\\"
-import { BookModelType } from \\"./BookModel\\"
-import { BookModelSelector, bookModelPrimitives } from \\"./BookModel.base\\"
-import { MovieModelType } from \\"./MovieModel\\"
-import { MovieModelSelector, movieModelPrimitives } from \\"./MovieModel.base\\"
-
-export type SearchItemUnion = MovieModelType | BookModelType
-
-export class SearchItemModelSelector extends QueryBuilder {
-  movie(builder?: string | MovieModelSelector | ((selector: MovieModelSelector) => MovieModelSelector)) { return this.__inlineFragment(\`Movie\`, MovieModelSelector, builder) }
-  book(builder?: string | BookModelSelector | ((selector: BookModelSelector) => BookModelSelector)) { return this.__inlineFragment(\`Book\`, BookModelSelector, builder) }
-}
-export function selectFromSearchItem() {
-  return new SearchItemModelSelector()
-}
-
-// provides all primitive fields of union member types combined together
-export const searchItemModelPrimitives = selectFromSearchItem().movie(movieModelPrimitives).book(bookModelPrimitives)",
-    true,
-  ],
-  Array [
     "MovieModel.base",
     "/* This is a mst-gql generated file, don't modify it manually */
 /* eslint-disable */
@@ -3052,6 +2956,102 @@ export const BookModel = BookModelBase
     false,
   ],
   Array [
+    "SearchItemModelSelector",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+import { QueryBuilder } from \\"mst-gql\\"
+import { BookModelType } from \\"./BookModel\\"
+import { BookModelSelector, bookModelPrimitives } from \\"./BookModel.base\\"
+import { MovieModelType } from \\"./MovieModel\\"
+import { MovieModelSelector, movieModelPrimitives } from \\"./MovieModel.base\\"
+
+export type SearchItemUnion = MovieModelType | BookModelType
+
+export class SearchItemModelSelector extends QueryBuilder {
+  movie(builder?: string | MovieModelSelector | ((selector: MovieModelSelector) => MovieModelSelector)) { return this.__inlineFragment(\`Movie\`, MovieModelSelector, builder) }
+  book(builder?: string | BookModelSelector | ((selector: BookModelSelector) => BookModelSelector)) { return this.__inlineFragment(\`Book\`, BookModelSelector, builder) }
+}
+export function selectFromSearchItem() {
+  return new SearchItemModelSelector()
+}
+
+// provides all primitive fields of union member types combined together
+export const searchItemModelPrimitives = selectFromSearchItem().movie(movieModelPrimitives).book(bookModelPrimitives)",
+    true,
+  ],
+  Array [
+    "SearchResultModel.base",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+import { types } from \\"mobx-state-tree\\"
+import { QueryBuilder } from \\"mst-gql\\"
+import { ModelBase } from \\"./ModelBase\\"
+import { BookModel, BookModelType } from \\"./BookModel\\"
+import { BookModelSelector } from \\"./BookModel.base\\"
+import { MovieModel, MovieModelType } from \\"./MovieModel\\"
+import { MovieModelSelector } from \\"./MovieModel.base\\"
+import { SearchItemModelSelector } from \\"./SearchItemModelSelector\\"
+import { RootStoreType } from \\"./index\\"
+
+
+/**
+ * SearchResultBase
+ * auto generated base class for the model SearchResultModel.
+ */
+export const SearchResultModelBase = ModelBase
+  .named('SearchResult')
+  .props({
+    __typename: types.optional(types.literal(\\"SearchResult\\"), \\"SearchResult\\"),
+    inputQuery: types.union(types.undefined, types.string),
+    items: types.union(types.undefined, types.array(types.union(types.null, types.union(types.late((): any => MovieModel), types.late((): any => BookModel))))),
+  })
+  .views(self => ({
+    get store() {
+      return self.__getStore<RootStoreType>()
+    }
+  }))
+
+export class SearchResultModelSelector extends QueryBuilder {
+  get inputQuery() { return this.__attr(\`inputQuery\`) }
+  items(builder: string | SearchItemModelSelector | ((selector: SearchItemModelSelector) => SearchItemModelSelector) | undefined) { return this.__child(\`items\`, SearchItemModelSelector, builder) }
+}
+export function selectFromSearchResult() {
+  return new SearchResultModelSelector()
+}
+
+export const searchResultModelPrimitives = selectFromSearchResult().inputQuery
+",
+    true,
+  ],
+  Array [
+    "SearchResultModel",
+    "import { Instance } from \\"mobx-state-tree\\"
+import { SearchResultModelBase } from \\"./SearchResultModel.base\\"
+
+/* The TypeScript type of an instance of SearchResultModel */
+export interface SearchResultModelType extends Instance<typeof SearchResultModel.Type> {}
+
+/* A graphql query fragment builders for SearchResultModel */
+export { selectFromSearchResult, searchResultModelPrimitives, SearchResultModelSelector } from \\"./SearchResultModel.base\\"
+
+/**
+ * SearchResultModel
+ */
+export const SearchResultModel = SearchResultModelBase
+  .actions(self => ({
+    // This is an auto-generated example action.
+    log() {
+      console.log(JSON.stringify(self))
+    }
+  }))
+",
+    false,
+  ],
+  Array [
     "RootStore",
     "import { Instance } from \\"mobx-state-tree\\"
 import { RootStoreBase } from \\"./RootStore.base\\"
@@ -3077,12 +3077,12 @@ import { ObservableMap } from \\"mobx\\"
 import { types } from \\"mobx-state-tree\\"
 import { MSTGQLStore, configureStoreMixin, QueryOptions, withTypedRefs } from \\"mst-gql\\"
 
-import { SearchResultModel, SearchResultModelType } from \\"./SearchResultModel\\"
-import { searchResultModelPrimitives, SearchResultModelSelector } from \\"./SearchResultModel.base\\"
 import { MovieModel, MovieModelType } from \\"./MovieModel\\"
 import { movieModelPrimitives, MovieModelSelector } from \\"./MovieModel.base\\"
 import { BookModel, BookModelType } from \\"./BookModel\\"
 import { bookModelPrimitives, BookModelSelector } from \\"./BookModel.base\\"
+import { SearchResultModel, SearchResultModelType } from \\"./SearchResultModel\\"
+import { searchResultModelPrimitives, SearchResultModelSelector } from \\"./SearchResultModel.base\\"
 
 import { searchItemModelPrimitives, SearchItemModelSelector , SearchItemUnion } from \\"./\\"
 
@@ -3106,7 +3106,7 @@ querySearch=\\"querySearch\\"
 */
 export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
   .named(\\"RootStore\\")
-  .extend(configureStoreMixin([['SearchResult', () => SearchResultModel], ['Movie', () => MovieModel], ['Book', () => BookModel]], ['SearchResult']))
+  .extend(configureStoreMixin([['Movie', () => MovieModel], ['Book', () => BookModel], ['SearchResult', () => SearchResultModel]], ['SearchResult']))
   .props({
     searchresults: types.optional(types.map(types.late((): any => SearchResultModel)), {})
   })
@@ -3142,10 +3142,10 @@ export const useQuery = createUseQueryHook(StoreContext, React)
 /* eslint-disable */
 /* tslint:disable */
 
-export * from \\"./SearchResultModel\\"
-export * from \\"./SearchItemModelSelector\\"
 export * from \\"./MovieModel\\"
 export * from \\"./BookModel\\"
+export * from \\"./SearchItemModelSelector\\"
+export * from \\"./SearchResultModel\\"
 export * from \\"./RootStore\\"
 export * from \\"./reactUtils\\"
 ",

--- a/tests/generator/generate.test.js
+++ b/tests/generator/generate.test.js
@@ -102,7 +102,7 @@ type query_root {
   expect(
     hasFileContent(
       findFile(output, "RootStore.base"),
-      `.extend(configureStoreMixin([['query_root', () => QueryRootModel], ['my_user', () => MyUserModel], ['possibly_empty_box', () => PossiblyEmptyBoxModel]], ['my_user', 'possibly_empty_box'], "js"))`
+      `.extend(configureStoreMixin([['my_user', () => MyUserModel], ['possibly_empty_box', () => PossiblyEmptyBoxModel], ['query_root', () => QueryRootModel]], ['my_user', 'possibly_empty_box'], "js"))`
     )
   ).toBeTruthy()
 })

--- a/tests/generator/generate.test.js
+++ b/tests/generator/generate.test.js
@@ -176,6 +176,7 @@ type Query {
       namingConvention: "asis"
     }
   )
+  console.log("+++ output", output)
   expect(output).toMatchSnapshot()
 
   expect(findFile(output, "SearchItemModelSelector")).toBeTruthy()

--- a/tests/lib/abstractTypes/models/RootStore.base.js
+++ b/tests/lib/abstractTypes/models/RootStore.base.js
@@ -3,18 +3,18 @@
 import { types } from "mobx-state-tree"
 import { MSTGQLStore, configureStoreMixin } from "mst-gql"
 
-import { SearchResultModel } from "./SearchResultModel"
-import { searchResultModelPrimitives, SearchResultModelSelector } from "./SearchResultModel.base"
 import { MovieModel } from "./MovieModel"
 import { movieModelPrimitives, MovieModelSelector } from "./MovieModel.base"
 import { BookModel } from "./BookModel"
 import { bookModelPrimitives, BookModelSelector } from "./BookModel.base"
-import { RepoModel } from "./RepoModel"
-import { repoModelPrimitives, RepoModelSelector } from "./RepoModel.base"
+import { SearchResultModel } from "./SearchResultModel"
+import { searchResultModelPrimitives, SearchResultModelSelector } from "./SearchResultModel.base"
 import { UserModel } from "./UserModel"
 import { userModelPrimitives, UserModelSelector } from "./UserModel.base"
 import { OrganizationModel } from "./OrganizationModel"
 import { organizationModelPrimitives, OrganizationModelSelector } from "./OrganizationModel.base"
+import { RepoModel } from "./RepoModel"
+import { repoModelPrimitives, RepoModelSelector } from "./RepoModel.base"
 
 import { searchItemModelPrimitives, SearchItemModelSelector  } from "./"
 import { ownerModelPrimitives, OwnerModelSelector  } from "./"
@@ -29,7 +29,7 @@ import { ownerModelPrimitives, OwnerModelSelector  } from "./"
 */
 export const RootStoreBase = MSTGQLStore
   .named("RootStore")
-  .extend(configureStoreMixin([['SearchResult', () => SearchResultModel], ['Movie', () => MovieModel], ['Book', () => BookModel], ['Repo', () => RepoModel], ['User', () => UserModel], ['Organization', () => OrganizationModel]], ['SearchResult', 'Repo']))
+  .extend(configureStoreMixin([['Movie', () => MovieModel], ['Book', () => BookModel], ['SearchResult', () => SearchResultModel], ['User', () => UserModel], ['Organization', () => OrganizationModel], ['Repo', () => RepoModel]], ['SearchResult', 'Repo']))
   .props({
     searchresults: types.optional(types.map(types.late(() => SearchResultModel)), {}),
     repos: types.optional(types.map(types.late(() => RepoModel)), {})

--- a/tests/lib/abstractTypes/models/index.js
+++ b/tests/lib/abstractTypes/models/index.js
@@ -1,13 +1,13 @@
 /* This is a mst-gql generated file, don't modify it manually */
 /* eslint-disable */
 
-export * from "./SearchResultModel"
-export * from "./SearchItemModelSelector"
 export * from "./MovieModel"
 export * from "./BookModel"
-export * from "./RepoModel"
+export * from "./SearchItemModelSelector"
+export * from "./SearchResultModel"
 export * from "./OwnerModelSelector"
 export * from "./UserModel"
 export * from "./OrganizationModel"
+export * from "./RepoModel"
 export * from "./RootStore"
 export * from "./reactUtils"

--- a/tests/lib/unionTypes/models/RootStore.base.js
+++ b/tests/lib/unionTypes/models/RootStore.base.js
@@ -3,12 +3,12 @@
 import { types } from "mobx-state-tree"
 import { MSTGQLStore, configureStoreMixin } from "mst-gql"
 
-import { TodoListModel } from "./TodoListModel"
-import { todoListModelPrimitives, TodoListModelSelector } from "./TodoListModel.base"
 import { BasicTodoModel } from "./BasicTodoModel"
 import { basicTodoModelPrimitives, BasicTodoModelSelector } from "./BasicTodoModel.base"
 import { FancyTodoModel } from "./FancyTodoModel"
 import { fancyTodoModelPrimitives, FancyTodoModelSelector } from "./FancyTodoModel.base"
+import { TodoListModel } from "./TodoListModel"
+import { todoListModelPrimitives, TodoListModelSelector } from "./TodoListModel.base"
 
 import { todoModelPrimitives, TodoModelSelector  } from "./"
 
@@ -22,7 +22,7 @@ import { todoModelPrimitives, TodoModelSelector  } from "./"
 */
 export const RootStoreBase = MSTGQLStore
   .named("RootStore")
-  .extend(configureStoreMixin([['TodoList', () => TodoListModel], ['BasicTodo', () => BasicTodoModel], ['FancyTodo', () => FancyTodoModel]], ['TodoList', 'BasicTodo', 'FancyTodo'], "js"))
+  .extend(configureStoreMixin([['BasicTodo', () => BasicTodoModel], ['FancyTodo', () => FancyTodoModel], ['TodoList', () => TodoListModel]], ['TodoList', 'BasicTodo', 'FancyTodo'], "js"))
   .props({
     todoLists: types.optional(types.map(types.late(() => TodoListModel)), {}),
     basicTodos: types.optional(types.map(types.late(() => BasicTodoModel)), {}),

--- a/tests/lib/unionTypes/models/index.js
+++ b/tests/lib/unionTypes/models/index.js
@@ -1,9 +1,9 @@
 /* This is a mst-gql generated file, don't modify it manually */
 /* eslint-disable */
 
-export * from "./TodoListModel"
 export * from "./TodoModelSelector"
 export * from "./BasicTodoModel"
 export * from "./FancyTodoModel"
+export * from "./TodoListModel"
 export * from "./RootStore"
 export * from "./reactUtils"

--- a/tests/test-cra.sh
+++ b/tests/test-cra.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Creates a new CRA app with the latest version of mst-gql dependencies added to it. An mst model is generated using
+# the graphql schema copied from examples/6-scaffolding-ts-hasura/schema.graphql and then the app is run to
+# see if it can run all right.
+#
+#
+# Note: the generated cra-test directory should not be checked into git. Unfortunately it cannot be added to .gitignore
+# otherwise relative-deps won't work (it ignores files in .gitignore).
+#
+
+rm -rf cra-test
+
+mkdir cra-test
+cd cra-test
+
+npx create-react-app cra-app --template typescript
+cd cra-app
+cp ../../../examples/6-scaffolding-ts-hasura/schema.graphql .
+yarn add mobx mobx-state-tree mobx-react react react-dom mst-gql graphql-request
+yarn add graphql graphql-tag
+yarn add relative-deps
+
+# Add current ms-gql version as relative dependency
+# perl -0777 -pi.original -e 's|\}$|},\n  "relativeDependencies": {\n    "mst-gql": "../../../"\n  }|sm' package.json
+npx relative-deps add ../../../
+
+# Load mst-gql relative deps
+node_modules/.bin/relative-deps
+
+# Add some code to import the generated files
+perl -0777 -pi.original -e 's|(import.*?./App.css.*?;)|\1\nimport {RootStore} from "./model/RootStore";\nconst rootStore = RootStore.create({})|sm' src/App.tsx
+
+# now generate models
+npx mst-gql --format ts --outDir src/model schema.graphql
+# Compile it
+npx tsc --extendedDiagnostics
+
+# run the project and check if runs all right. Not sure how portable or exact this is, but seems to work
+rm -f out
+yarn start | tee ./out 2>&1 &
+
+echo -n "Checking if app runs all right "
+for i in {1..20}
+do
+  # Failed to compile.
+  failed=`egrep 'Failed to compile|ERROR in' out`
+  if [[ ! -z ${failed} ]]; then
+    echo
+    echo "App failed to compile"
+    pid=`ps -ef | grep tests/cra-test/cra-app | grep -v grep | awk '{print $2}' -`
+    kill -9 $pid > /dev/null 2>&1
+    exit
+  fi
+
+  no_issues=`grep 'No issues found.' out | wc -l`
+  if [ "$no_issues" -eq "1" ]; then
+    echo
+    echo "App ran successfully!"
+    pid=`ps -ef | grep tests/cra-test/cra-app | grep -v grep | awk '{print $2}' -`
+    kill -9 $pid > /dev/null 2>&1
+    exit
+  fi
+
+  echo -n "."
+
+  sleep 3
+done
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -3516,12 +3516,12 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
-cross-fetch@^3.0.6:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.4.tgz#9723f3a3a247bf8b89039f3a380a9244e8fa2f39"
-  integrity sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==
+cross-fetch@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
+  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
   dependencies:
-    node-fetch "2.6.1"
+    node-fetch "2.6.7"
 
 cross-spawn@^6.0.5:
   version "6.0.5"
@@ -4579,12 +4579,12 @@ graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
-graphql-request@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-4.0.0.tgz#5e4361d33df1a95ccd7ad23a8ebb6bbca9d5622f"
-  integrity sha512-cdqQLCXlBGkaLdkLYRl4LtkwaZU6TfpE7/tnUQFl3wXfUPWN74Ov+Q61VuIh+AltS789YfGB6whghmCmeXLvTw==
+graphql-request@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-4.2.0.tgz#063377bc2dd29cc46aed3fddcc65fe97b805ba81"
+  integrity sha512-uFeMyhhl8ss4LFgjlfPeAn2pqYw+CJto+cjj71uaBYIMMK2jPIqgHm5KEFxUk0YDD41A8Bq31a2b4G2WJBlp2Q==
   dependencies:
-    cross-fetch "^3.0.6"
+    cross-fetch "^3.1.5"
     extract-files "^9.0.0"
     form-data "^3.0.0"
 
@@ -4607,12 +4607,10 @@ graphql-tag@^2.12.4:
   dependencies:
     tslib "^2.1.0"
 
-"graphql@14.0.2 - 14.2.0 || ^14.3.1 || ^15.0.0", graphql@14.6.0:
-  version "14.6.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.6.0.tgz#57822297111e874ea12f5cd4419616930cd83e49"
-  integrity sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==
-  dependencies:
-    iterall "^1.2.2"
+"graphql@14.0.2 - 14.2.0 || ^14.3.1 || ^15.0.0", graphql@^16.3.0:
+  version "16.3.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.3.0.tgz#a91e24d10babf9e60c706919bb182b53ccdffc05"
+  integrity sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==
 
 gzip-size@^3.0.0:
   version "3.0.0"
@@ -5210,7 +5208,7 @@ istanbul-reports@^3.0.2:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-iterall@^1.2.1, iterall@^1.2.2:
+iterall@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
   integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
@@ -6373,10 +6371,12 @@ no-case@^3.0.3:
     lower-case "^2.0.1"
     tslib "^1.10.0"
 
-node-fetch@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+node-fetch@2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-fetch@^2.6.1:
   version "2.6.2"
@@ -8285,6 +8285,11 @@ tr46@^2.1.0:
   dependencies:
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 treeify@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/treeify/-/treeify-1.1.0.tgz#4e31c6a463accd0943879f30667c4fdaff411bb8"
@@ -8575,6 +8580,11 @@ walker@^1.0.7:
   dependencies:
     makeerror "1.0.x"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
 webidl-conversions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
@@ -8596,6 +8606,14 @@ whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whatwg-url@^8.0.0:
   version "8.2.2"


### PR DESCRIPTION
Upgrades graphql to "^16.3.0" so that it works with new CRA apps, which use webpack 5.

Added tests/test-cra.sh, which creates a new CRA app with the latest mst-gql and the necessary dependencies, checks whether generation, tsc compilation and running the app succeeds.

Fixes #365.
