### PR TITLE
Add support of type import to --fieldOverrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ The `mst-gql` command currently accepts the following arguments:
     For TS users, input types and query arguments will only be modified for fieldOverrides with a wildcard for `gqlFieldName` (`*:uuid:identifier`). An override like `*_id:uuid:identifier` will not affect input types.
 
     The primary use case for this feature is for GQL Servers that don't always do what you want. For example, Hasura does not generate GQL ID types for UUID fields, which causes issues when trying to reference associate types in MST. To overcome this, simply specify `--fieldOverrides *:UUID:identifier`
+  - `*.timestamp:*:DateScalar:../scalars` - Matches any GQL type with the field name `timestamp`, and uses the MST type `DateScalar` imported from file `../scalars`. Usually used for `graphql custom scalar` support with MST `type.custom`
 
 - `source` The last argument is the location at which to find the graphQL definitions. This can be
   - a graphql endpoint, like `http://host/graphql`

--- a/generator/config.js
+++ b/generator/config.js
@@ -71,7 +71,7 @@ const parseFieldOverrides = (fieldOverrides) => {
     .map((item) => {
       const override = item.split(":").map((s) => s.trim())
 
-      if (override.length !== 3)
+      if (!(override.length === 3 || override.length === 4))
         throw new Error("--fieldOverrides used with invalid override: " + item)
 
       return override

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -453,14 +453,18 @@ ${generateFragments(name, primitiveFields, nonPrimitiveFields)}
       switch (fieldType.kind) {
         case "SCALAR":
           primitiveFields.push(fieldName)
-          const primitiveType = primitiveToMstType(
+          const [primitiveType, typeImportPath] = primitiveToMstType(
             fieldName,
             fieldType.name,
             typeOverride
           )
           const requiredTypes = ["identifier", "identifierNumber"]
           const isRequired = requiredTypes.includes(primitiveType)
-          return result(`types.${primitiveType}`, isRequired)
+          if (typeImportPath) {
+            addImport(typeImportPath, primitiveType)
+          }
+          const typeName = typeImportPath ?  primitiveType :`types.${primitiveType}`
+          return result(typeName, isRequired)
         case "OBJECT":
           return result(
             handleObjectFieldType(fieldName, fieldType, fieldArgs, isNested)
@@ -1140,7 +1144,11 @@ ${toExport.map((f) => `export * from "./${f}${importPostFix}"`).join("\n")}
       Boolean: "boolean"
     }
     // if (!res[type]) throw new Error("Unknown primitive type: " + type)
-    return res[type] || "frozen()"
+    if (res[type]) {
+      return [ res[type], undefined]
+    } else {
+      return ["frozen()", undefined]
+    }
   }
 
   return files
@@ -1509,7 +1517,12 @@ function buildOverrides(fieldOverrides, useIdentifierNumber) {
   }
 
   function parseFieldOverride(override) {
-    const [unsplitFieldName, fieldType, destinationMstType] = override
+    const [
+      unsplitFieldName,
+      fieldType,
+      destinationMstType,
+      typeImportPath
+    ] = override
 
     const splitFieldName = unsplitFieldName.split(".")
     const fieldDeclaringType =
@@ -1521,7 +1534,8 @@ function buildOverrides(fieldOverrides, useIdentifierNumber) {
       fieldDeclaringType,
       fieldName,
       fieldType,
-      destinationMstType
+      destinationMstType,
+      typeImportPath
     )
   }
 }
@@ -1556,12 +1570,12 @@ function TypeOverride(currentType, overrides) {
         override &&
         override.specificity === mostSpecificIdOverride.specificity
       )
-        return override.destinationMstType
+        return [override.destinationMstType, override.typeImportPath]
 
-      return "frozen()"
+      return ["frozen()", undefined]
     }
 
-    return override && override.destinationMstType
+    return override && [override.destinationMstType, override.typeImportPath]
   }
 
   return {
@@ -1610,7 +1624,8 @@ function Override(
   fieldDeclaringType,
   fieldName,
   fieldType,
-  destinationMstType
+  destinationMstType,
+  typeImportPath
 ) {
   const specificity = computeOverrideSpecificity(
     fieldDeclaringType,
@@ -1635,7 +1650,8 @@ function Override(
   return {
     matches,
     specificity,
-    destinationMstType
+    destinationMstType,
+    typeImportPath
   }
 
   /*

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -67,7 +67,7 @@ test("config is used for multiple headers", () => {
 
 test("fieldOverrides outputs items with valid signature", () => {
   const fieldOverridesArgs = {
-    "--fieldOverrides": "id:uuid:identifier, id:bigint:identifierNumber"
+    "--fieldOverrides": "id:uuid:identifier, id:bigint:identifierNumber, *:Date:Date:../scalars"
   }
   const args = { ...testArgsWithoutHeader, ...fieldOverridesArgs }
   const config = {
@@ -81,7 +81,8 @@ test("fieldOverrides outputs items with valid signature", () => {
 
   expect(results.fieldOverrides).toEqual([
     ["id", "uuid", "identifier"],
-    ["id", "bigint", "identifierNumber"]
+    ["id", "bigint", "identifierNumber"],
+    ["*", "Date", "Date", "../scalars"],
   ])
 })
 

--- a/tests/generator/__snapshots__/generate.test.js.snap
+++ b/tests/generator/__snapshots__/generate.test.js.snap
@@ -1808,6 +1808,74 @@ export const BookModel = BookModelBase
     false,
   ],
   Array [
+    "MessageModel.base",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+import { types } from \\"mobx-state-tree\\"
+import { QueryBuilder } from \\"mst-gql\\"
+import { ModelBase } from \\"./ModelBase\\"
+import { DateScalar } from \\"./../scalars\\"
+import { RootStoreType } from \\"./index\\"
+
+
+/**
+ * MessageBase
+ * auto generated base class for the model MessageModel.
+ */
+export const MessageModelBase = ModelBase
+  .named('Message')
+  .props({
+    __typename: types.optional(types.literal(\\"Message\\"), \\"Message\\"),
+    id: types.identifier,
+    text: types.union(types.undefined, types.string),
+    timestamp: types.union(types.undefined, DateScalar),
+  })
+  .views(self => ({
+    get store() {
+      return self.__getStore<RootStoreType>()
+    }
+  }))
+
+export class MessageModelSelector extends QueryBuilder {
+  get id() { return this.__attr(\`id\`) }
+  get text() { return this.__attr(\`text\`) }
+  get timestamp() { return this.__attr(\`timestamp\`) }
+}
+export function selectFromMessage() {
+  return new MessageModelSelector()
+}
+
+export const messageModelPrimitives = selectFromMessage().text.timestamp
+",
+    true,
+  ],
+  Array [
+    "MessageModel",
+    "import { Instance } from \\"mobx-state-tree\\"
+import { MessageModelBase } from \\"./MessageModel.base\\"
+
+/* The TypeScript type of an instance of MessageModel */
+export interface MessageModelType extends Instance<typeof MessageModel.Type> {}
+
+/* A graphql query fragment builders for MessageModel */
+export { selectFromMessage, messageModelPrimitives, MessageModelSelector } from \\"./MessageModel.base\\"
+
+/**
+ * MessageModel
+ */
+export const MessageModel = MessageModelBase
+  .actions(self => ({
+    // This is an auto-generated example action.
+    log() {
+      console.log(JSON.stringify(self))
+    }
+  }))
+",
+    false,
+  ],
+  Array [
     "RootStore",
     "import { Instance } from \\"mobx-state-tree\\"
 import { RootStoreBase } from \\"./RootStore.base\\"
@@ -1837,6 +1905,8 @@ import { UserModel, UserModelType } from \\"./UserModel\\"
 import { userModelPrimitives, UserModelSelector } from \\"./UserModel.base\\"
 import { BookModel, BookModelType } from \\"./BookModel\\"
 import { bookModelPrimitives, BookModelSelector } from \\"./BookModel.base\\"
+import { MessageModel, MessageModelType } from \\"./MessageModel\\"
+import { messageModelPrimitives, MessageModelSelector } from \\"./MessageModel.base\\"
 
 
 
@@ -1860,7 +1930,7 @@ queryBook=\\"queryBook\\"
 */
 export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
   .named(\\"RootStore\\")
-  .extend(configureStoreMixin([['User', () => UserModel], ['Book', () => BookModel]], ['User'], \\"js\\"))
+  .extend(configureStoreMixin([['User', () => UserModel], ['Book', () => BookModel], ['Message', () => MessageModel]], ['User'], \\"js\\"))
   .props({
     users: types.optional(types.map(types.late((): any => UserModel)), {})
   })
@@ -1903,6 +1973,7 @@ export const useQuery = createUseQueryHook(StoreContext, React)
 
 export * from \\"./UserModel\\"
 export * from \\"./BookModel\\"
+export * from \\"./MessageModel\\"
 export * from \\"./RootStore\\"
 export * from \\"./reactUtils\\"
 ",
@@ -2296,6 +2367,73 @@ export const BookModel = BookModelBase
     false,
   ],
   Array [
+    "MessageModel.base",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+import { types } from \\"mobx-state-tree\\"
+import { QueryBuilder } from \\"mst-gql\\"
+import { ModelBase } from \\"./ModelBase\\"
+import { RootStoreType } from \\"./index\\"
+
+
+/**
+ * MessageBase
+ * auto generated base class for the model MessageModel.
+ */
+export const MessageModelBase = ModelBase
+  .named('Message')
+  .props({
+    __typename: types.optional(types.literal(\\"Message\\"), \\"Message\\"),
+    id: types.identifier,
+    text: types.union(types.undefined, types.string),
+    timestamp: types.union(types.undefined, types.frozen()),
+  })
+  .views(self => ({
+    get store() {
+      return self.__getStore<RootStoreType>()
+    }
+  }))
+
+export class MessageModelSelector extends QueryBuilder {
+  get id() { return this.__attr(\`id\`) }
+  get text() { return this.__attr(\`text\`) }
+  get timestamp() { return this.__attr(\`timestamp\`) }
+}
+export function selectFromMessage() {
+  return new MessageModelSelector()
+}
+
+export const messageModelPrimitives = selectFromMessage().text.timestamp
+",
+    true,
+  ],
+  Array [
+    "MessageModel",
+    "import { Instance } from \\"mobx-state-tree\\"
+import { MessageModelBase } from \\"./MessageModel.base\\"
+
+/* The TypeScript type of an instance of MessageModel */
+export interface MessageModelType extends Instance<typeof MessageModel.Type> {}
+
+/* A graphql query fragment builders for MessageModel */
+export { selectFromMessage, messageModelPrimitives, MessageModelSelector } from \\"./MessageModel.base\\"
+
+/**
+ * MessageModel
+ */
+export const MessageModel = MessageModelBase
+  .actions(self => ({
+    // This is an auto-generated example action.
+    log() {
+      console.log(JSON.stringify(self))
+    }
+  }))
+",
+    false,
+  ],
+  Array [
     "RootStore",
     "import { Instance } from \\"mobx-state-tree\\"
 import { RootStoreBase } from \\"./RootStore.base\\"
@@ -2325,6 +2463,8 @@ import { UserModel, UserModelType } from \\"./UserModel\\"
 import { userModelPrimitives, UserModelSelector } from \\"./UserModel.base\\"
 import { BookModel, BookModelType } from \\"./BookModel\\"
 import { bookModelPrimitives, BookModelSelector } from \\"./BookModel.base\\"
+import { MessageModel, MessageModelType } from \\"./MessageModel\\"
+import { messageModelPrimitives, MessageModelSelector } from \\"./MessageModel.base\\"
 
 
 
@@ -2348,7 +2488,7 @@ queryBook=\\"queryBook\\"
 */
 export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
   .named(\\"RootStore\\")
-  .extend(configureStoreMixin([['User', () => UserModel], ['Book', () => BookModel]], ['User'], \\"js\\"))
+  .extend(configureStoreMixin([['User', () => UserModel], ['Book', () => BookModel], ['Message', () => MessageModel]], ['User'], \\"js\\"))
   .props({
     users: types.optional(types.map(types.late((): any => UserModel)), {})
   })
@@ -2391,6 +2531,7 @@ export const useQuery = createUseQueryHook(StoreContext, React)
 
 export * from \\"./UserModel\\"
 export * from \\"./BookModel\\"
+export * from \\"./MessageModel\\"
 export * from \\"./RootStore\\"
 export * from \\"./reactUtils\\"
 ",
@@ -2540,6 +2681,73 @@ export const BookModel = BookModelBase
     false,
   ],
   Array [
+    "MessageModel.base",
+    "/* This is a mst-gql generated file, don't modify it manually */
+/* eslint-disable */
+/* tslint:disable */
+
+import { types } from \\"mobx-state-tree\\"
+import { QueryBuilder } from \\"mst-gql\\"
+import { ModelBase } from \\"./ModelBase\\"
+import { RootStoreType } from \\"./index\\"
+
+
+/**
+ * MessageBase
+ * auto generated base class for the model MessageModel.
+ */
+export const MessageModelBase = ModelBase
+  .named('Message')
+  .props({
+    __typename: types.optional(types.literal(\\"Message\\"), \\"Message\\"),
+    id: types.identifier,
+    text: types.union(types.undefined, types.string),
+    timestamp: types.union(types.undefined, types.frozen()),
+  })
+  .views(self => ({
+    get store() {
+      return self.__getStore<RootStoreType>()
+    }
+  }))
+
+export class MessageModelSelector extends QueryBuilder {
+  get id() { return this.__attr(\`id\`) }
+  get text() { return this.__attr(\`text\`) }
+  get timestamp() { return this.__attr(\`timestamp\`) }
+}
+export function selectFromMessage() {
+  return new MessageModelSelector()
+}
+
+export const messageModelPrimitives = selectFromMessage().text.timestamp
+",
+    true,
+  ],
+  Array [
+    "MessageModel",
+    "import { Instance } from \\"mobx-state-tree\\"
+import { MessageModelBase } from \\"./MessageModel.base\\"
+
+/* The TypeScript type of an instance of MessageModel */
+export interface MessageModelType extends Instance<typeof MessageModel.Type> {}
+
+/* A graphql query fragment builders for MessageModel */
+export { selectFromMessage, messageModelPrimitives, MessageModelSelector } from \\"./MessageModel.base\\"
+
+/**
+ * MessageModel
+ */
+export const MessageModel = MessageModelBase
+  .actions(self => ({
+    // This is an auto-generated example action.
+    log() {
+      console.log(JSON.stringify(self))
+    }
+  }))
+",
+    false,
+  ],
+  Array [
     "RootStore",
     "import { Instance } from \\"mobx-state-tree\\"
 import { RootStoreBase } from \\"./RootStore.base\\"
@@ -2569,6 +2777,8 @@ import { UserModel, UserModelType } from \\"./UserModel\\"
 import { userModelPrimitives, UserModelSelector } from \\"./UserModel.base\\"
 import { BookModel, BookModelType } from \\"./BookModel\\"
 import { bookModelPrimitives, BookModelSelector } from \\"./BookModel.base\\"
+import { MessageModel, MessageModelType } from \\"./MessageModel\\"
+import { messageModelPrimitives, MessageModelSelector } from \\"./MessageModel.base\\"
 
 
 
@@ -2592,7 +2802,7 @@ queryBook=\\"queryBook\\"
 */
 export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
   .named(\\"RootStore\\")
-  .extend(configureStoreMixin([['User', () => UserModel], ['Book', () => BookModel]], ['User'], \\"js\\"))
+  .extend(configureStoreMixin([['User', () => UserModel], ['Book', () => BookModel], ['Message', () => MessageModel]], ['User'], \\"js\\"))
   .props({
     users: types.optional(types.map(types.late((): any => UserModel)), {})
   })
@@ -2635,6 +2845,7 @@ export const useQuery = createUseQueryHook(StoreContext, React)
 
 export * from \\"./UserModel\\"
 export * from \\"./BookModel\\"
+export * from \\"./MessageModel\\"
 export * from \\"./RootStore\\"
 export * from \\"./reactUtils\\"
 ",

--- a/tests/generator/generate.test.js
+++ b/tests/generator/generate.test.js
@@ -494,6 +494,7 @@ test("use identifierNumber as ID with useIdentifierNumber=true", () => {
 const fieldOverridesSchema = `
   scalar uuid
   scalar bigint
+  scalar Date
 
   type User {
     id: bigint!
@@ -507,6 +508,13 @@ const fieldOverridesSchema = `
     me: User,
     book: Book
   }
+
+  type Message {
+    id: ID!
+    text: String!
+    timestamp: Date!
+  }
+
 `
 
 test("overrides mst type with matching name and gql type using fieldOverrides", () => {
@@ -514,7 +522,8 @@ test("overrides mst type with matching name and gql type using fieldOverrides", 
     roots: ["User"],
     fieldOverrides: [
       ["id", "uuid", "identifier"],
-      ["User.id", "bigint", "identifierNumber"]
+      ["User.id", "bigint", "identifierNumber"],
+      ["*", "Date", "DateScalar", "../scalars"],
     ]
   })
 


### PR DESCRIPTION
One more fragment in fieldOverrides allows to import type definition
from file. May be used for custom scalars support with MST type.custom()