### PR TITLE
Scaffold nullable types as "(type | null)"

### DIFF
--- a/generator/generate.js
+++ b/generator/generate.js
@@ -1032,7 +1032,7 @@ ${optPrefix("\n    // ", sanitizeComment(description))}
 
     return `${name}${
       canBeUndefined || fromUndefineableList ? "?" : ""
-    }: ${typeValue}`
+    }: ${canBeUndefined ? `(${typeValue} | null)` : typeValue}`
   }
 
   function printTsPrimitiveType(primitiveType) {


### PR DESCRIPTION
Nullable types are generated as optional in typescript files. This makes the fields of `type | undefined`.

 When you try to set `null` as such field, TS compiler refuses to assign `null` to optional field.

The main problem is that it prevents sending `null` to backend to erase field value in mutation.

Workaround is to do something like this
```ts
store.mutateSetSomething({
  value: null as unknown as undefined,
})
```

This PR fixes this by generating nullable types as `(type | null)`.