### PR TITLE
V0.16.0 graphql ws subscribe

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "editor.tabSize": 3,
   "eslint.enable": false,
   "cSpell.enabled": false,
   "typescript.tsdk": "node_modules/typescript/lib"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mst-gql",
-  "version": "0.16.0",
+  "version": "0.15.0",
   "description": "Bindings for mobx-state-tree and GraphQL",
   "author": "Michel Weststrate",
   "keywords": [
@@ -31,7 +31,7 @@
     "generator"
   ],
   "scripts": {
-    "test": "jest test && cd examples/2-scaffolding && yarn && yarn start && cd ../6-scaffolding-ts-hasura && yarn && yarn start && cd ../../tests && ./test-cra.sh && rm -rf cra-test",
+    "test": "jest test && cd examples/2-scaffolding && yarn && yarn start",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",
     "watch": "jest test --watch",
     "build": "microbundle --no-compress --external mobx,mobx-react,mobx-state-tree,graphql-tag,graphql,react,react-dom,graphql-request",
@@ -48,8 +48,9 @@
     "camelcase": "^6.2.0",
     "cosmiconfig": "^7.0.0",
     "fast-json-stable-stringify": "^2.1.0",
-    "graphql": "^16.3.0",
-    "graphql-request": "^4.2.0",
+    "graphql": "14.6.0",
+    "graphql-request": "^4.0.0",
+    "graphql-ws": "^5.9.1",
     "lodash": "^4.17.21",
     "pluralize": "^8.0.0",
     "throttle-debounce": "^3.0.1"
@@ -74,9 +75,9 @@
     "husky": "^6.0.0",
     "jest": "^27.0.1",
     "microbundle": "^0.13.1",
-    "mobx": "^6.1.0",
-    "mobx-react": "^7.2.0",
-    "mobx-state-tree": "^5.0.1",
+    "mobx": "^6.6.0",
+    "mobx-react": "^7.3.0",
+    "mobx-state-tree": "^5.1.3",
     "prettier": "^2.3.0",
     "pretty-quick": "^3.1.0",
     "react": "^17.0.2",
@@ -86,10 +87,10 @@
     "typescript": "^4.3.2"
   },
   "peerDependencies": {
-    "mobx": "^6.3.2",
-    "mobx-state-tree": "^5.0.1"
+    "mobx": "^6.6.0",
+    "mobx-state-tree": "^5.1.3"
   },
   "resolutions": {
-    "graphql": "^16.3.0"
+    "graphql": "15.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mst-gql",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Bindings for mobx-state-tree and GraphQL",
   "author": "Michel Weststrate",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@types/jest": "^26.0.23",
     "@types/lodash": "^4.14.170",
     "@types/pluralize": "^0.0.29",
-    "@types/react": "^17.0.8",
+    "@types/react": "^17.0.40",
     "@types/react-dom": "^17.0.5",
     "@types/throttle-debounce": "^2.1.0",
     "@types/ws": "7.4.4",

--- a/src/MSTGQLStore.ts
+++ b/src/MSTGQLStore.ts
@@ -1,15 +1,15 @@
 import camelcase from "camelcase"
 import { DocumentNode } from "graphql"
 import {
-  getEnv,
-  IAnyModelType,
-  Instance,
-  recordPatches,
-  types
+   getEnv,
+   IAnyModelType,
+   Instance,
+   recordPatches,
+   types
 } from "mobx-state-tree"
 import pluralize from "pluralize"
 import { SubscriptionClient } from "subscriptions-transport-ws"
-import { HttpClientOptions } from "./createHttpClient"
+import { Client as GraphqlClient } from 'graphql-ws';
 
 import { deflateHelper } from "./deflateHelper"
 import { mergeHelper } from "./mergeHelper"
@@ -17,235 +17,270 @@ import { Query, QueryHttpClientOptions, QueryOptions } from "./Query"
 import { getFirstValue } from "./utils"
 
 type RequestOptions = {
-  document: string
-  variables?: any
-  signal?: QueryHttpClientOptions["signal"]
+   document: string
+   variables?: any
+   signal?: QueryHttpClientOptions["signal"]
 }
 
 export type RequestHandler<T = any> = {
-  request(query: string, variables: any): Promise<T>
-  request(options?: RequestOptions): Promise<T>
+   request(query: string, variables: any): Promise<T>
+   request(options?: RequestOptions): Promise<T>
 }
 
 // TODO: also provide an interface for stream handler
 
 export const MSTGQLStore = types
-  .model("MSTGQLStore", {
-    __queryCache: types.optional(types.map(types.frozen()), {})
-  })
-  .volatile(
-    (
-      self
-    ): {
-      ssr: boolean
-      __promises: Map<string, Promise<unknown>>
-      __afterInit: boolean
-      gqlHttpClient: RequestHandler
-      gqlWsClient: SubscriptionClient
-    } => {
-      const {
-        ssr = false,
-        gqlHttpClient,
-        gqlWsClient
-      }: {
-        ssr: boolean
-        gqlHttpClient: RequestHandler
-        gqlWsClient: SubscriptionClient
-      } = getEnv(self)
+   .model("MSTGQLStore", {
+      __queryCache: types.optional(types.map(types.frozen()), {})
+   })
+   .volatile(
+      (
+         self
+      ): {
+         ssr: boolean
+         __promises: Map<string, Promise<unknown>>
+         __afterInit: boolean
+         gqlHttpClient: RequestHandler
+         gqlWsClient: SubscriptionClient
+         graphqlWsClient: GraphqlClient
+      } => {
+         const {
+            ssr = false,
+            gqlHttpClient,
+            gqlWsClient,
+            graphqlWsClient
+         }: {
+            ssr: boolean
+            gqlHttpClient: RequestHandler
+            gqlWsClient: SubscriptionClient
+            graphqlWsClient: GraphqlClient
+         } = getEnv(self)
+         return {
+            ssr,
+            gqlHttpClient,
+            gqlWsClient,
+            __promises: new Map(),
+            __afterInit: false,
+            graphqlWsClient
+         }
+      }
+   )
+   .actions((self) => {
+      Promise.resolve().then(() => (self as any).__onAfterInit())
+
+      function merge(data: unknown) {
+         return mergeHelper(self, data)
+      }
+
+      function deflate(data: unknown) {
+         return deflateHelper(self, data)
+      }
+
+      function rawRequest(
+         query: string,
+         variables: any,
+         options?: QueryHttpClientOptions
+      ): Promise<any> {
+         if (!self.gqlHttpClient && !self.gqlWsClient)
+            throw new Error(
+               "Either gqlHttpClient or gqlWsClient (or both) should provided in the MSTGQLStore environment"
+            )
+         if (self.gqlHttpClient) {
+            if (options)
+               return self.gqlHttpClient.request({
+                  document: query,
+                  variables,
+                  signal: options.signal
+               })
+            else return self.gqlHttpClient.request(query, variables)
+         } else {
+            return new Promise((resolve, reject) => {
+               self.gqlWsClient
+                  .request({
+                     query,
+                     variables
+                  })
+                  .subscribe({
+                     next(data) {
+                        resolve(data.data)
+                     },
+                     error: reject
+                  })
+            })
+         }
+      }
+
+      function query<T>(
+         query: string | DocumentNode,
+         variables?: any,
+         options: QueryOptions = {}
+      ): Query<T> {
+         return new Query(self as StoreType, query, variables, options)
+      }
+
+      function mutate<T>(
+         mutation: string | DocumentNode,
+         variables?: any,
+         optimisticUpdate?: () => void
+      ): Query<T> {
+         if (optimisticUpdate) {
+            const recorder = recordPatches(self)
+            optimisticUpdate()
+            recorder.stop()
+            const q = query<T>(mutation, variables, {
+               fetchPolicy: "network-only"
+            })
+            q.currentPromise().catch(() => {
+               recorder.undo()
+            })
+            return q
+         } else {
+            return query(mutation, variables, {
+               fetchPolicy: "network-only"
+            })
+         }
+      }
+
+      // N.b: the T is ignored, but it does simplify code generation
+      function subscribe<T = any>(
+         query: string | DocumentNode | undefined,
+         variables?: any,
+         onData?: (item: T) => void,
+         onError: (error: Error) => void = (error) => {
+            throw error
+         }
+      ): () => void {
+         let cleanup: () => void;
+         if (self.graphqlWsClient) {
+            cleanup = self.graphqlWsClient
+               .subscribe(
+                  {
+                     query: query ? query.toString() : '',
+                  },
+                  {
+                     next: (data) => {
+                        (self as any).__runInStoreContext(() => {
+                           // CABDEBUG
+                           console.log('DATA', JSON.stringify(data));
+                           const res = (self as any).merge(getFirstValue(data))
+                           if (onData) onData(res)
+                           return res
+                        })
+                     },
+                     // error: (error) => { onError(new Error(JSON.stringify(error))) },
+                     error: (error) => { console.error('graphqlWsClient subscribe error', error) },
+                     complete: () => { console.log('graphqlWsClient complete') },
+                  },
+               )
+         }
+         else {
+            if (!self.gqlWsClient) throw new Error("No WS client available")
+            const sub = self.gqlWsClient
+               .request({
+                  query: query ? query.toString() : '',
+                  variables
+               })
+               .subscribe({
+                  next(data) {
+                     if (data.errors) {
+                        return onError(new Error(JSON.stringify(data.errors)))
+                     }
+                     ; (self as any).__runInStoreContext(() => {
+                        const res = (self as any).merge(getFirstValue(data.data))
+                        if (onData) onData(res)
+                        return res
+                     })
+                  }
+               });
+            cleanup = () => { sub.unsubscribe() }
+         }
+         return cleanup
+      }
+
+      function setHttpClient(value: RequestHandler) {
+         self.gqlHttpClient = value
+      }
+
+      function setWsClient(value: SubscriptionClient) {
+         self.gqlWsClient = value
+      }
+
+      function setGraphqlWsClient(value: GraphqlClient) {
+         self.graphqlWsClient = value
+      }
+
+      // exposed actions
       return {
-        ssr,
-        gqlHttpClient,
-        gqlWsClient,
-        __promises: new Map(),
-        __afterInit: false
+         merge,
+         deflate,
+         mutate,
+         query,
+         subscribe,
+         rawRequest,
+         setHttpClient,
+         setWsClient,
+         setGraphqlWsClient,
+         __pushPromise(promise: Promise<{}>, queryKey: string) {
+            self.__promises.set(queryKey, promise)
+            const onSettled = () => self.__promises.delete(queryKey)
+            promise.then(onSettled, onSettled)
+         },
+         __runInStoreContext<T>(fn: () => T) {
+            return fn()
+         },
+         __cacheResponse(key: string, response: any) {
+            self.__queryCache.set(key, response)
+         },
+         __onAfterInit() {
+            self.__afterInit = true
+         }
       }
-    }
-  )
-  .actions((self) => {
-    Promise.resolve().then(() => (self as any).__onAfterInit())
-
-    function merge(data: unknown) {
-      return mergeHelper(self, data)
-    }
-
-    function deflate(data: unknown) {
-      return deflateHelper(self, data)
-    }
-
-    function rawRequest(
-      query: string,
-      variables: any,
-      options?: QueryHttpClientOptions
-    ): Promise<any> {
-      if (!self.gqlHttpClient && !self.gqlWsClient)
-        throw new Error(
-          "Either gqlHttpClient or gqlWsClient (or both) should provided in the MSTGQLStore environment"
-        )
-      if (self.gqlHttpClient) {
-        if (options)
-          return self.gqlHttpClient.request({
-            document: query,
-            variables,
-            signal: options.signal
-          })
-        else return self.gqlHttpClient.request(query, variables)
-      } else {
-        return new Promise((resolve, reject) => {
-          self.gqlWsClient
-            .request({
-              query,
-              variables
-            })
-            .subscribe({
-              next(data) {
-                resolve(data.data)
-              },
-              error: reject
-            })
-        })
-      }
-    }
-
-    function query<T>(
-      query: string | DocumentNode,
-      variables?: any,
-      options: QueryOptions = {}
-    ): Query<T> {
-      return new Query(self as StoreType, query, variables, options)
-    }
-
-    function mutate<T>(
-      mutation: string | DocumentNode,
-      variables?: any,
-      optimisticUpdate?: () => void
-    ): Query<T> {
-      if (optimisticUpdate) {
-        const recorder = recordPatches(self)
-        optimisticUpdate()
-        recorder.stop()
-        const q = query<T>(mutation, variables, {
-          fetchPolicy: "network-only"
-        })
-        q.currentPromise().catch(() => {
-          recorder.undo()
-        })
-        return q
-      } else {
-        return query(mutation, variables, {
-          fetchPolicy: "network-only"
-        })
-      }
-    }
-
-    // N.b: the T is ignored, but it does simplify code generation
-    function subscribe<T = any>(
-      query: string | DocumentNode,
-      variables?: any,
-      onData?: (item: T) => void,
-      onError: (error: Error) => void = (error) => {
-        throw error
-      }
-    ): () => void {
-      if (!self.gqlWsClient) throw new Error("No WS client available")
-      const sub = self.gqlWsClient
-        .request({
-          query,
-          variables
-        })
-        .subscribe({
-          next(data) {
-            if (data.errors) {
-              return onError(new Error(JSON.stringify(data.errors)))
-            }
-            ;(self as any).__runInStoreContext(() => {
-              const res = (self as any).merge(getFirstValue(data.data))
-              if (onData) onData(res)
-              return res
-            })
-          }
-        })
-      return () => sub.unsubscribe()
-    }
-
-    function setHttpClient(value: RequestHandler) {
-      self.gqlHttpClient = value
-    }
-
-    function setWsClient(value: SubscriptionClient) {
-      self.gqlWsClient = value
-    }
-
-    // exposed actions
-    return {
-      merge,
-      deflate,
-      mutate,
-      query,
-      subscribe,
-      rawRequest,
-      setHttpClient,
-      setWsClient,
-      __pushPromise(promise: Promise<{}>, queryKey: string) {
-        self.__promises.set(queryKey, promise)
-        const onSettled = () => self.__promises.delete(queryKey)
-        promise.then(onSettled, onSettled)
-      },
-      __runInStoreContext<T>(fn: () => T) {
-        return fn()
-      },
-      __cacheResponse(key: string, response: any) {
-        self.__queryCache.set(key, response)
-      },
-      __onAfterInit() {
-        self.__afterInit = true
-      }
-    }
-  })
+   })
 
 export function configureStoreMixin(
-  knownTypes: [string, () => IAnyModelType][],
-  rootTypes: string[],
-  namingConvention?: string
+   knownTypes: [string, () => IAnyModelType][],
+   rootTypes: string[],
+   namingConvention?: string
 ) {
-  const kt = new Map()
-  const rt = new Set(rootTypes)
-  return () => ({
-    actions: {
-      afterCreate() {
-        // initialized lazily, so that there are no circular dep issues
-        knownTypes.forEach(([key, typeFn]) => {
-          const type = typeFn()
-          if (!type)
-            throw new Error(
-              `The type provided for '${key}' is empty. Probably this is a module loading issue`
-            )
-          kt.set(key, type)
-        })
+   const kt = new Map()
+   const rt = new Set(rootTypes)
+   return () => ({
+      actions: {
+         afterCreate() {
+            // initialized lazily, so that there are no circular dep issues
+            knownTypes.forEach(([key, typeFn]) => {
+               const type = typeFn()
+               if (!type)
+                  throw new Error(
+                     `The type provided for '${key}' is empty. Probably this is a module loading issue`
+                  )
+               kt.set(key, type)
+            })
+         }
+      },
+      views: {
+         isKnownType(typename: string): boolean {
+            return kt.has(typename)
+         },
+         isRootType(typename: string): boolean {
+            return rt.has(typename)
+         },
+         getTypeDef(typename: string): IAnyModelType {
+            return kt.get(typename)!
+         },
+         getCollectionName(typename: string): string {
+            if (namingConvention == "js") {
+               // Pluralize only last word (pluralize may fail with words that are
+               // not valid English words as is the case with LongCamelCaseTypeNames)
+               const newName = camelcase(typename)
+               const parts = newName.split(/(?=[A-Z])/)
+               parts[parts.length - 1] = pluralize(parts[parts.length - 1])
+               return parts.join("")
+            }
+            return typename.toLowerCase() + "s"
+         }
       }
-    },
-    views: {
-      isKnownType(typename: string): boolean {
-        return kt.has(typename)
-      },
-      isRootType(typename: string): boolean {
-        return rt.has(typename)
-      },
-      getTypeDef(typename: string): IAnyModelType {
-        return kt.get(typename)!
-      },
-      getCollectionName(typename: string): string {
-        if (namingConvention == "js") {
-          // Pluralize only last word (pluralize may fail with words that are
-          // not valid English words as is the case with LongCamelCaseTypeNames)
-          const newName = camelcase(typename)
-          const parts = newName.split(/(?=[A-Z])/)
-          parts[parts.length - 1] = pluralize(parts[parts.length - 1])
-          return parts.join("")
-        }
-        return typename.toLowerCase() + "s"
-      }
-    }
-  })
+   })
 }
 
 export type StoreType = Instance<typeof MSTGQLStore>

--- a/src/mergeHelper.ts
+++ b/src/mergeHelper.ts
@@ -2,43 +2,52 @@ import { resolveIdentifier } from "mobx-state-tree"
 import { typenameToCollectionName } from "./utils"
 
 export function mergeHelper(store: any, data: any) {
-  function merge(data: any): any {
-    if (!data || typeof data !== "object") return data
-    if (Array.isArray(data)) return data.map(merge)
+   function merge(data: any): any {
+      if (!data || typeof data !== "object") return data
+      if (Array.isArray(data)) return data.map(merge)
 
-    const { __typename, id } = data
+      const { __typename, id } = data
 
-    // convert values deeply first to MST objects as much as possible
-    const snapshot: any = {}
-    for (const key in data) {
-      snapshot[key] = merge(data[key])
-    }
-
-    // GQL object
-    if (__typename && store.isKnownType(__typename)) {
-      // GQL object with known type, instantiate or recycle MST object
-      const typeDef = store.getTypeDef(__typename)
-      // Try to reuse instance, even if it is not a root type
-      let instance = id !== undefined && resolveIdentifier(typeDef, store, id)
-      if (instance) {
-        // update existing object
-        Object.assign(instance, snapshot)
-      } else {
-        // create a new one
-        instance = typeDef.create(snapshot)
-        if (store.isRootType(__typename)) {
-          // register in the store if a root
-          //store[typenameToCollectionName(__typename)].set(id, instance)
-          store[store.getCollectionName(__typename)].set(id, instance)
-        }
-        instance.__setStore(store)
+      // convert values deeply first to MST objects as much as possible
+      const snapshot: any = {}
+      for (const key in data) {
+         snapshot[key] = merge(data[key])
       }
-      return instance
-    } else {
-      // GQL object with unknown type, return verbatim
-      return snapshot
-    }
-  }
 
-  return merge(data)
+      // GQL object
+      if (__typename && store.isKnownType(__typename)) {
+         // GQL object with known type, instantiate or recycle MST object
+         const typeDef = store.getTypeDef(__typename)
+         // CABDEBUG
+         if (__typename === 'Operation') console.log('typeDef', typeDef);
+         // Try to reuse instance, even if it is not a root type
+         let instance = id !== undefined && resolveIdentifier(typeDef, store, id)
+         if (instance) {
+            // update existing object
+            Object.assign(instance, snapshot)
+         } else {
+            // CABDEBUG
+            if (__typename === 'Operation') {
+               console.log('snapshot', snapshot);
+            }
+
+            // create a new one
+            instance = typeDef.create(snapshot)
+            // CABDEBUG
+            if (__typename === 'Operation') console.log('new instance', JSON.stringify(instance));
+            if (store.isRootType(__typename)) {
+               // register in the store if a root
+               //store[typenameToCollectionName(__typename)].set(id, instance)
+               store[store.getCollectionName(__typename)].set(id, instance)
+            }
+            instance.__setStore(store)
+         }
+         return instance
+      } else {
+         // GQL object with unknown type, return verbatim
+         return snapshot
+      }
+   }
+
+   return merge(data)
 }

--- a/src/mergeHelper.ts
+++ b/src/mergeHelper.ts
@@ -18,23 +18,14 @@ export function mergeHelper(store: any, data: any) {
       if (__typename && store.isKnownType(__typename)) {
          // GQL object with known type, instantiate or recycle MST object
          const typeDef = store.getTypeDef(__typename)
-         // CABDEBUG
-         if (__typename === 'Operation') console.log('typeDef', typeDef);
          // Try to reuse instance, even if it is not a root type
          let instance = id !== undefined && resolveIdentifier(typeDef, store, id)
          if (instance) {
             // update existing object
             Object.assign(instance, snapshot)
          } else {
-            // CABDEBUG
-            if (__typename === 'Operation') {
-               console.log('snapshot', snapshot);
-            }
-
             // create a new one
             instance = typeDef.create(snapshot)
-            // CABDEBUG
-            if (__typename === 'Operation') console.log('new instance', JSON.stringify(instance));
             if (store.isRootType(__typename)) {
                // register in the store if a root
                //store[typenameToCollectionName(__typename)].set(id, instance)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3064,15 +3064,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001038:
-  version "1.0.30001040"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001040.tgz#103fc8e6eb1d7397e95134cd0e996743353d58ea"
-  integrity sha512-Ep0tEPeI5wCvmJNrXjE3etgfI+lkl1fTDU6Y3ZH1mhrjkPlVI9W4pcKbMo+BQLpEWKVYYp2EmYaRsqpPC3k7lQ==
-
-caniuse-lite@^1.0.30001252, caniuse-lite@^1.0.30001254:
-  version "1.0.30001257"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001257.tgz#150aaf649a48bee531104cfeda57f92ce587f6e5"
-  integrity sha512-JN49KplOgHSXpIsVSF+LUyhD8PUp6xPpAXeRrrcBh4KBeP7W864jHn6RvzJgDlrReyeVjMFJL3PLpPvKIxlIHA==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001038, caniuse-lite@^1.0.30001252, caniuse-lite@^1.0.30001254:
+  version "1.0.30001365"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001365.tgz"
+  integrity sha512-VDQZ8OtpuIPMBA4YYvZXECtXbddMCUFJk1qu8Mqxfm/SZJNSr1cy4IuLCOL7RJ/YASrvJcYg1Zh+UEUQ5m6z8Q==
 
 capital-case@^1.0.3:
   version "1.0.3"
@@ -4579,10 +4574,10 @@ graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
-graphql-request@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-4.2.0.tgz#063377bc2dd29cc46aed3fddcc65fe97b805ba81"
-  integrity sha512-uFeMyhhl8ss4LFgjlfPeAn2pqYw+CJto+cjj71uaBYIMMK2jPIqgHm5KEFxUk0YDD41A8Bq31a2b4G2WJBlp2Q==
+graphql-request@^4.0.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-4.3.0.tgz#b934e08fcae764aa2cdc697d3c821f046cb5dbf2"
+  integrity sha512-2v6hQViJvSsifK606AliqiNiijb1uwWp6Re7o0RTyH+uRTv/u7Uqm2g4Fjq/LgZIzARB38RZEvVBFOQOVdlBow==
   dependencies:
     cross-fetch "^3.1.5"
     extract-files "^9.0.0"
@@ -4607,10 +4602,22 @@ graphql-tag@^2.12.4:
   dependencies:
     tslib "^2.1.0"
 
-"graphql@14.0.2 - 14.2.0 || ^14.3.1 || ^15.0.0", graphql@^16.3.0:
-  version "16.3.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.3.0.tgz#a91e24d10babf9e60c706919bb182b53ccdffc05"
-  integrity sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==
+graphql-ws@^5.9.1:
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.9.1.tgz#9c0fa48ceb695d61d574ed3ab21b426729e87f2d"
+  integrity sha512-mL/SWGBwIT9Meq0NlfS55yXXTOeWPMbK7bZBEZhFu46bcGk1coTx2Sdtzxdk+9yHWngD+Fk1PZDWaAutQa9tpw==
+
+"graphql@14.0.2 - 14.2.0 || ^14.3.1 || ^15.0.0", graphql@15.8.0:
+  version "15.8.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.8.0.tgz#33410e96b012fa3bdb1091cc99a94769db212b38"
+  integrity sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==
+
+graphql@14.6.0:
+  version "14.6.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.6.0.tgz#57822297111e874ea12f5cd4419616930cd83e49"
+  integrity sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==
+  dependencies:
+    iterall "^1.2.2"
 
 gzip-size@^3.0.0:
   version "3.0.0"
@@ -5208,7 +5215,7 @@ istanbul-reports@^3.0.2:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-iterall@^1.2.1:
+iterall@^1.2.1, iterall@^1.2.2:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
   integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
@@ -6263,27 +6270,27 @@ mkdirp@1.0.4, mkdirp@^1.0.3:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mobx-react-lite@^3.2.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-3.2.1.tgz#c549a3722f1eae51a78b12f839311614d5689c58"
-  integrity sha512-hwURgfmP2apX3HQrB55V9DN47kuN3C6KlQvI5UIfJRibXma72C/JudcNt2r9dWjAdFMrcZoz1ivvtXMCkJ2aQA==
+mobx-react-lite@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-3.4.0.tgz#d59156a96889cdadad751e5e4dab95f28926dfff"
+  integrity sha512-bRuZp3C0itgLKHu/VNxi66DN/XVkQG7xtoBVWxpvC5FhAqbOCP21+nPhULjnzEqd7xBMybp6KwytdUpZKEgpIQ==
 
-mobx-react@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/mobx-react/-/mobx-react-7.2.0.tgz#241e925e963bb83a31d269f65f9f379e37ecbaeb"
-  integrity sha512-KHUjZ3HBmZlNnPd1M82jcdVsQRDlfym38zJhZEs33VxyVQTvL77hODCArq6+C1P1k/6erEeo2R7rpE7ZeOL7dg==
+mobx-react@^7.3.0:
+  version "7.5.2"
+  resolved "https://registry.yarnpkg.com/mobx-react/-/mobx-react-7.5.2.tgz#362d6dc7271698caf3b56229c3c68fb0b30e682e"
+  integrity sha512-NP44ONwSqTy+3KlD7y9k7xbsuGD+8mgUj3IeI65SbxF1IOB42/j9TbosgUEDn//CCuU6OmQ7k9oiu9eSpRBHnw==
   dependencies:
-    mobx-react-lite "^3.2.0"
+    mobx-react-lite "^3.4.0"
 
-mobx-state-tree@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/mobx-state-tree/-/mobx-state-tree-5.0.1.tgz#d495725fe11075d8fde8f02ab65db6736b44e014"
-  integrity sha512-XZafwF1sJe6sp8L1kgf9Tz0SLo/UPf2pxsonnHaBQNsqbebw+0GC+IT3WxPEIe0/aQ73q4nY4SRgW1uyfd1KRA==
+mobx-state-tree@^5.1.3:
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/mobx-state-tree/-/mobx-state-tree-5.1.5.tgz#7344d61072705747abb98d23ad21302e38200105"
+  integrity sha512-jugIic0PYWW+nzzYfp4RUy9dec002Z778OC6KzoOyBHnqxupK9iPCsUJYkHjmNRHjZ8E4Z7qQpsKV3At/ntGVw==
 
-mobx@^6.1.0:
-  version "6.1.8"
-  resolved "https://registry.yarnpkg.com/mobx/-/mobx-6.1.8.tgz#5d03cb76d8f7694dd82bfb2578d886945b66450d"
-  integrity sha512-U4yCvUeh6yKXRwFxm2lyJjXPVekOEar/R8ZKWAXem/3fthJqYflViawfjDAUh7lZEvbKqljC3NT/pSaUKpE+gg==
+mobx@^6.6.0:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/mobx/-/mobx-6.6.1.tgz#70ee6aa82f25aeb7e7d522bd621207434e509318"
+  integrity sha512-7su3UZv5JF+ohLr2opabjbUAERfXstMY+wiBtey8yNAPoB8H187RaQXuhFjNkH8aE4iHbDWnhDFZw0+5ic4nGQ==
 
 moment@2.29.1:
   version "2.29.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2202,10 +2202,10 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
-"@types/react@^17.0.8":
-  version "17.0.20"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.20.tgz#a4284b184d47975c71658cd69e759b6bd37c3b8c"
-  integrity sha512-wWZrPlihslrPpcKyCSlmIlruakxr57/buQN1RjlIeaaTWDLtJkTtRW429MoQJergvVKc4IWBpRhWw7YNh/7GVA==
+"@types/react@^17.0.40":
+  version "17.0.47"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.47.tgz#4ee71aaf4c5a9e290e03aa4d0d313c5d666b3b78"
+  integrity sha512-mk0BL8zBinf2ozNr3qPnlu1oyVTYq+4V7WA76RgxUAtf0Em/Wbid38KN6n4abEkvO4xMTBWmnP1FtQzgkEiJoA==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
This change adds graphql-ws support only for subscriptions. 

Is backwards compatible so still works with subscription-transport-ws without code changes.

Only difference is in new transport parameter for example:
```
      const gqlHttpClient = createHttpClient(httpUrl, {
         headers: {
            authorization: 'Bearer ' + token,
         }
      });

      const graphqlWsClient = createClient({
         url: wsUrl,
         connectionParams: {
            jwt: token,
         }
      });

      {
         gqlHttpClient,
         graphqlWsClient // instead of gqlWsClient
      }
```
