### PR TITLE
Support [String] as query return type

### DIFF
--- a/generator/generate.js
+++ b/generator/generate.js
@@ -905,14 +905,14 @@ ${enumContent}
 
         let { name, origName, args, type, description } = field
 
-        const isScalar =
-          type.kind === "SCALAR" ||
-          (type.ofType && type.ofType.kind === "SCALAR")
-
         if (type.kind === "NON_NULL") type = type.ofType
         const returnsList = type.kind === "LIST"
         let returnType = returnsList ? type.ofType : type
         if (returnType.kind === "NON_NULL") returnType = returnType.ofType
+
+        const isScalar =
+          returnType.kind === "SCALAR" ||
+          (returnType.ofType && returnType.ofType.kind === "SCALAR")
 
         /** 4) Add the return type of the query if TS */
         const tsType =
@@ -920,14 +920,14 @@ ${enumContent}
             ? ""
             : `<{ ${name}: ${
                 isScalar
-                  ? `${printTsPrimitiveType(type.name)} `
+                  ? `${printTsPrimitiveType(returnType.name)}`
                   : `${returnType.name}${
                       returnType.kind === "UNION" ||
                       returnType.kind === "INTERFACE"
                         ? "Union"
                         : modelTypePostfix
-                    }${returnsList ? "[]" : ""}`
-              }}>`
+                    }`
+              }${returnsList ? "[]" : ""} }>`
 
         let formalArgs = ""
         let actualArgs = ""

--- a/tests/generator/__snapshots__/generate.test.js.snap
+++ b/tests/generator/__snapshots__/generate.test.js.snap
@@ -133,7 +133,7 @@ export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
   })
   .actions(self => ({
     queryMe(variables?: {  }, resultSelector: string | ((qb: UserModelSelector) => UserModelSelector) = userModelPrimitives.toString(), options: QueryOptions = {}) {
-      return self.query<{ me: UserModelType}>(\`query me { me {
+      return self.query<{ me: UserModelType }>(\`query me { me {
         \${typeof resultSelector === \\"function\\" ? resultSelector(new UserModelSelector()).toString() : resultSelector}
       } }\`, variables, options)
     },
@@ -456,7 +456,7 @@ export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
   })
   .actions(self => ({
     queryMe(variables?: {  }, resultSelector: string | ((qb: MyUserModelSelector) => MyUserModelSelector) = myUserModelPrimitives.toString(), options: QueryOptions = {}) {
-      return self.query<{ me: MyUserModelType}>(\`query me { me {
+      return self.query<{ me: MyUserModelType }>(\`query me { me {
         \${typeof resultSelector === \\"function\\" ? resultSelector(new MyUserModelSelector()).toString() : resultSelector}
       } }\`, variables, options)
     },
@@ -632,7 +632,7 @@ export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
   })
   .actions(self => ({
     queryMe(variables?: {  }, resultSelector: string | ((qb: UserModelSelector) => UserModelSelector) = userModelPrimitives.toString(), options: QueryOptions = {}) {
-      return self.query<{ me: UserModelType}>(\`query me { me {
+      return self.query<{ me: UserModelType }>(\`query me { me {
         \${typeof resultSelector === \\"function\\" ? resultSelector(new UserModelSelector()).toString() : resultSelector}
       } }\`, variables, options)
     },
@@ -871,7 +871,7 @@ export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
   })
   .actions(self => ({
     queryMe(variables?: {  }, resultSelector: string | ((qb: UserModelSelector) => UserModelSelector) = userModelPrimitives.toString(), options: QueryOptions = {}) {
-      return self.query<{ me: UserModelType}>(\`query me { me {
+      return self.query<{ me: UserModelType }>(\`query me { me {
         \${typeof resultSelector === \\"function\\" ? resultSelector(new UserModelSelector()).toString() : resultSelector}
       } }\`, variables, options)
     },
@@ -1109,7 +1109,7 @@ export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
   })
   .actions(self => ({
     queryMe(variables?: {  }, resultSelector: string | ((qb: UserModelSelector) => UserModelSelector) = userModelPrimitives.toString(), options: QueryOptions = {}) {
-      return self.query<{ me: UserModelType}>(\`query me { me {
+      return self.query<{ me: UserModelType }>(\`query me { me {
         \${typeof resultSelector === \\"function\\" ? resultSelector(new UserModelSelector()).toString() : resultSelector}
       } }\`, variables, options)
     },
@@ -1452,7 +1452,7 @@ export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
   })
   .actions(self => ({
     queryRepo(variables?: {  }, resultSelector: string | ((qb: RepoModelSelector) => RepoModelSelector) = repoModelPrimitives.toString(), options: QueryOptions = {}) {
-      return self.query<{ repo: RepoModelType}>(\`query repo { repo {
+      return self.query<{ repo: RepoModelType }>(\`query repo { repo {
         \${typeof resultSelector === \\"function\\" ? resultSelector(new RepoModelSelector()).toString() : resultSelector}
       } }\`, variables, options)
     },
@@ -1628,7 +1628,7 @@ export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
   })
   .actions(self => ({
     queryGetUser(variables: { input?: (UserInput | null) }, resultSelector: string | ((qb: UserModelSelector) => UserModelSelector) = userModelPrimitives.toString(), options: QueryOptions = {}) {
-      return self.query<{ getUser: UserModelType}>(\`query getUser($input: UserInput) { getUser(input: $input) {
+      return self.query<{ getUser: UserModelType }>(\`query getUser($input: UserInput) { getUser(input: $input) {
         \${typeof resultSelector === \\"function\\" ? resultSelector(new UserModelSelector()).toString() : resultSelector}
       } }\`, variables, options)
     },
@@ -1936,12 +1936,12 @@ export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
   })
   .actions(self => ({
     queryMe(variables?: {  }, resultSelector: string | ((qb: UserModelSelector) => UserModelSelector) = userModelPrimitives.toString(), options: QueryOptions = {}) {
-      return self.query<{ me: UserModelType}>(\`query me { me {
+      return self.query<{ me: UserModelType }>(\`query me { me {
         \${typeof resultSelector === \\"function\\" ? resultSelector(new UserModelSelector()).toString() : resultSelector}
       } }\`, variables, options)
     },
     queryBook(variables?: {  }, resultSelector: string | ((qb: BookModelSelector) => BookModelSelector) = bookModelPrimitives.toString(), options: QueryOptions = {}) {
-      return self.query<{ book: BookModelType}>(\`query book { book {
+      return self.query<{ book: BookModelType }>(\`query book { book {
         \${typeof resultSelector === \\"function\\" ? resultSelector(new BookModelSelector()).toString() : resultSelector}
       } }\`, variables, options)
     },
@@ -2181,12 +2181,12 @@ export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
   })
   .actions(self => ({
     queryMe(variables?: {  }, resultSelector: string | ((qb: UserModelSelector) => UserModelSelector) = userModelPrimitives.toString(), options: QueryOptions = {}) {
-      return self.query<{ me: UserModelType}>(\`query me { me {
+      return self.query<{ me: UserModelType }>(\`query me { me {
         \${typeof resultSelector === \\"function\\" ? resultSelector(new UserModelSelector()).toString() : resultSelector}
       } }\`, variables, options)
     },
     queryBook(variables?: {  }, resultSelector: string | ((qb: BookModelSelector) => BookModelSelector) = bookModelPrimitives.toString(), options: QueryOptions = {}) {
-      return self.query<{ book: BookModelType}>(\`query book { book {
+      return self.query<{ book: BookModelType }>(\`query book { book {
         \${typeof resultSelector === \\"function\\" ? resultSelector(new BookModelSelector()).toString() : resultSelector}
       } }\`, variables, options)
     },
@@ -2494,12 +2494,12 @@ export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
   })
   .actions(self => ({
     queryMe(variables?: {  }, resultSelector: string | ((qb: UserModelSelector) => UserModelSelector) = userModelPrimitives.toString(), options: QueryOptions = {}) {
-      return self.query<{ me: UserModelType}>(\`query me { me {
+      return self.query<{ me: UserModelType }>(\`query me { me {
         \${typeof resultSelector === \\"function\\" ? resultSelector(new UserModelSelector()).toString() : resultSelector}
       } }\`, variables, options)
     },
     queryBook(variables?: {  }, resultSelector: string | ((qb: BookModelSelector) => BookModelSelector) = bookModelPrimitives.toString(), options: QueryOptions = {}) {
-      return self.query<{ book: BookModelType}>(\`query book { book {
+      return self.query<{ book: BookModelType }>(\`query book { book {
         \${typeof resultSelector === \\"function\\" ? resultSelector(new BookModelSelector()).toString() : resultSelector}
       } }\`, variables, options)
     },
@@ -2808,12 +2808,12 @@ export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
   })
   .actions(self => ({
     queryMe(variables?: {  }, resultSelector: string | ((qb: UserModelSelector) => UserModelSelector) = userModelPrimitives.toString(), options: QueryOptions = {}) {
-      return self.query<{ me: UserModelType}>(\`query me { me {
+      return self.query<{ me: UserModelType }>(\`query me { me {
         \${typeof resultSelector === \\"function\\" ? resultSelector(new UserModelSelector()).toString() : resultSelector}
       } }\`, variables, options)
     },
     queryBook(variables?: {  }, resultSelector: string | ((qb: BookModelSelector) => BookModelSelector) = bookModelPrimitives.toString(), options: QueryOptions = {}) {
-      return self.query<{ book: BookModelType}>(\`query book { book {
+      return self.query<{ book: BookModelType }>(\`query book { book {
         \${typeof resultSelector === \\"function\\" ? resultSelector(new BookModelSelector()).toString() : resultSelector}
       } }\`, variables, options)
     },
@@ -2987,7 +2987,7 @@ export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
       return self.query<{ helloWithString: string }>(\`query helloWithString { helloWithString }\`, variables, options)
     },
     queryHelloWithType(variables?: {  }, resultSelector: string | ((qb: HelloResultModelSelector) => HelloResultModelSelector) = helloResultModelPrimitives.toString(), options: QueryOptions = {}) {
-      return self.query<{ helloWithType: HelloResultModelType}>(\`query helloWithType { helloWithType {
+      return self.query<{ helloWithType: HelloResultModelType }>(\`query helloWithType { helloWithType {
         \${typeof resultSelector === \\"function\\" ? resultSelector(new HelloResultModelSelector()).toString() : resultSelector}
       } }\`, variables, options)
     },
@@ -3323,7 +3323,7 @@ export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
   })
   .actions(self => ({
     querySearch(variables: { text: string }, resultSelector: string | ((qb: SearchResultModelSelector) => SearchResultModelSelector) = searchResultModelPrimitives.toString(), options: QueryOptions = {}) {
-      return self.query<{ search: SearchResultModelType}>(\`query search($text: String!) { search(text: $text) {
+      return self.query<{ search: SearchResultModelType }>(\`query search($text: String!) { search(text: $text) {
         \${typeof resultSelector === \\"function\\" ? resultSelector(new SearchResultModelSelector()).toString() : resultSelector}
       } }\`, variables, options)
     },
@@ -3502,12 +3502,12 @@ export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
   })
   .actions(self => ({
     queryUser(variables: { id: number }, resultSelector: string | ((qb: UserModelSelector) => UserModelSelector) = userModelPrimitives.toString(), options: QueryOptions = {}) {
-      return self.query<{ user: UserModelType}>(\`query user($id: ID!) { user(id: $id) {
+      return self.query<{ user: UserModelType }>(\`query user($id: ID!) { user(id: $id) {
         \${typeof resultSelector === \\"function\\" ? resultSelector(new UserModelSelector()).toString() : resultSelector}
       } }\`, variables, options)
     },
     queryUsers(variables: { input: UsersFilter }, resultSelector: string | ((qb: UserModelSelector) => UserModelSelector) = userModelPrimitives.toString(), options: QueryOptions = {}) {
-      return self.query<{ users: UserModelType[]}>(\`query users($input: UsersFilter!) { users(input: $input) {
+      return self.query<{ users: UserModelType[] }>(\`query users($input: UsersFilter!) { users(input: $input) {
         \${typeof resultSelector === \\"function\\" ? resultSelector(new UserModelSelector()).toString() : resultSelector}
       } }\`, variables, options)
     },
@@ -3749,12 +3749,12 @@ export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
   })
   .actions(self => ({
     queryMe(variables?: {  }, resultSelector: string | ((qb: UserModelSelector) => UserModelSelector) = userModelPrimitives.toString(), options: QueryOptions = {}) {
-      return self.query<{ me: UserModelType}>(\`query me { me {
+      return self.query<{ me: UserModelType }>(\`query me { me {
         \${typeof resultSelector === \\"function\\" ? resultSelector(new UserModelSelector()).toString() : resultSelector}
       } }\`, variables, options)
     },
     queryBook(variables?: {  }, resultSelector: string | ((qb: BookModelSelector) => BookModelSelector) = bookModelPrimitives.toString(), options: QueryOptions = {}) {
-      return self.query<{ book: BookModelType}>(\`query book { book {
+      return self.query<{ book: BookModelType }>(\`query book { book {
         \${typeof resultSelector === \\"function\\" ? resultSelector(new BookModelSelector()).toString() : resultSelector}
       } }\`, variables, options)
     },
@@ -3929,7 +3929,7 @@ export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
   })
   .actions(self => ({
     querySearch(variables: { text?: MovieInput[] }, resultSelector: string | ((qb: MovieModelSelector) => MovieModelSelector) = movieModelPrimitives.toString(), options: QueryOptions = {}) {
-      return self.query<{ search: MovieModelType}>(\`query search($text: [MovieInput!]) { search(text: $text) {
+      return self.query<{ search: MovieModelType }>(\`query search($text: [MovieInput!]) { search(text: $text) {
         \${typeof resultSelector === \\"function\\" ? resultSelector(new MovieModelSelector()).toString() : resultSelector}
       } }\`, variables, options)
     },


### PR DESCRIPTION
Queries having return type of `[String]` get scaffolded as

```typescript
      queryFetchStuff(
        variables?: {},
        resultSelector: string | ((qb: StringModelSelector) => StringModelSelector) = stringModelPrimitives.toString(),
        options: QueryOptions = {}
      ) {
        return self.query<{ fetchStuff: StringModelType[] }>(
          `query fetchStuff { fetchStuff {
        ${typeof resultSelector === 'function' ? resultSelector(new StringModelSelector()).toString() : resultSelector}
      } }`,
          variables,
          options
        )
      },
```

treating `String` as a complex type. Obviously there is no `StringModelSelector` generated and build fails.

This change fixes that, generating proper query function.

```typescript
      queryFetchStuff(variables?: {}, options: QueryOptions = {}) {
        return self.query<{ fetchStuff: string[] }>(`query fetchStuff { fetchStuff }`, variables, options)
      },
```
