### PR TITLE
feat: Scaffold nullable lists as "type[] | null"

### DIFF
--- a/generator/generate.js
+++ b/generator/generate.js
@@ -1043,7 +1043,7 @@ ${optPrefix("\n    // ", sanitizeComment(description))}
       case "NON_NULL":
         return printTsType(type.ofType, name, false, fromUndefineableList)
       case "LIST":
-        return `${printTsType(type.ofType, name, true, canBeUndefined)}[]`
+        return `${printTsType(type.ofType, name, true, canBeUndefined)}[]${canBeUndefined ? " | null" : ""}`
       case "OBJECT":
       case "INPUT_OBJECT":
       case "ENUM":

--- a/tests/generator/__snapshots__/generate.test.js.snap
+++ b/tests/generator/__snapshots__/generate.test.js.snap
@@ -3902,7 +3902,7 @@ import { movieModelPrimitives, MovieModelSelector } from \\"./MovieModel.base\\"
 
 export type MovieInput = {
   description: string[]
-  director?: string[]
+  director?: string[] | null
 }
 /* The TypeScript type that explicits the refs to other models in order to prevent a circular refs issue */
 type Refs = {
@@ -3928,7 +3928,7 @@ export const RootStoreBase = withTypedRefs<Refs>()(MSTGQLStore
 
   })
   .actions(self => ({
-    querySearch(variables: { text?: MovieInput[] }, resultSelector: string | ((qb: MovieModelSelector) => MovieModelSelector) = movieModelPrimitives.toString(), options: QueryOptions = {}) {
+    querySearch(variables: { text?: MovieInput[] | null }, resultSelector: string | ((qb: MovieModelSelector) => MovieModelSelector) = movieModelPrimitives.toString(), options: QueryOptions = {}) {
       return self.query<{ search: MovieModelType }>(\`query search($text: [MovieInput!]) { search(text: $text) {
         \${typeof resultSelector === \\"function\\" ? resultSelector(new MovieModelSelector()).toString() : resultSelector}
       } }\`, variables, options)

--- a/tests/generator/generate.test.js
+++ b/tests/generator/generate.test.js
@@ -216,7 +216,7 @@ type Query {
   expect(
     hasFileContent(
       searchResultBase,
-      "querySearch(variables: { text?: MovieInput[] },"
+      "querySearch(variables: { text?: MovieInput[] | null },"
     )
   ).toBeTruthy()
 


### PR DESCRIPTION
This is a follow-up to #378 which added `| null` to nullable fields.

This extends support to nullable lists. When a field is of list type and is nullabble, it will be scaffolded as:
```
  field?: SomeType[] | null
```