### PR TITLE
fix parse config fieldOverrides

### DIFF
--- a/generator/config.js
+++ b/generator/config.js
@@ -72,7 +72,7 @@ exports.mergeConfigs = function mergeConfigs(args, config) {
       !!args["--useIdentifierNumber"] || config.useIdentifierNumber,
     fieldOverrides: args["--fieldOverrides"]
       ? parseFieldOverrides(args["--fieldOverrides"])
-      : config.fieldOverrides,
+      : parseFieldOverrides(config.fieldOverrides),
     dynamicArgs: !!args["--dynamicArgs"] || config.dynamicArgs,
     debug: !!args["--debug"] || config.debug,
     disableLogColors: !!args["--disableLogColors"] || config.disableLogColors
@@ -80,8 +80,10 @@ exports.mergeConfigs = function mergeConfigs(args, config) {
 }
 
 const parseFieldOverrides = (fieldOverrides) => {
-  return fieldOverrides
-    .split(",")
+  const _fieldOverrides = 
+    Array.isArray(fieldOverrides) ? fieldOverrides : fieldOverrides.split(",");
+
+  return _fieldOverrides
     .map((s) => s.trim())
     .map((item) => {
       const override = item.split(":").map((s) => s.trim())


### PR DESCRIPTION
When the "fieldOverrides" configuration was passed in a config file (like "mst-gql.config.js") as an array, it was not working because it was not formatted with "parseFieldOverrides", needing to create a different value field like "[["*_id", "\*", "string"]]", when it should be just "["*_id:*:string"]".